### PR TITLE
Support for CDA view of entities

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project
 
-Contentful Commander — a Go library and CLI for Contentful CMA migrations. Provides a unified `Entity` interface over entries and assets, locale-aware field access, batch migration execution, and DeepL translation integration.
+Contentful Commander — a Go library and CLI for Contentful CMA migrations. Provides a unified `Entity` interface over entries and assets, locale-aware field access, dual CMA/CDA loading with CDA views, batch migration execution, and DeepL translation integration.
 
 **Go 1.25** · module `github.com/foomo/contentfulcommander`
 
@@ -42,7 +42,7 @@ Single library package (`commanderclient/`) with a thin CLI entry point (`main.g
 
 - **`Entity` interface** (`types.go`) — unified API over `EntryEntity` and `AssetEntity`. All field access is locale-aware with fallback support. Publishing status derived from version arithmetic: `draft` (PublishedVersion==0), `published` (Version-PublishedVersion==1), `changed` (>1).
 
-- **`MigrationClient`** (`client.go`) — wraps the foomo/contentful CMA SDK. `LoadSpaceModel()` fetches locales, content types, entries, and assets concurrently into a `SpaceModel` cache. Provides entity lookups and filtering.
+- **`MigrationClient`** (`client.go`) — wraps the foomo/contentful CMA SDK. Optionally pairs a CDA client for published-view access. `LoadSpaceModel()` fetches locales, content types, entries, and assets concurrently into a `SpaceModel` cache. When a CDA key is provided, CDA views are loaded and attached to each entity (`entity.HasCDAView()`, `entity.CDAView()`). Set `Config.SkipAssets = true` to skip asset loading entirely. Provides entity lookups and filtering.
 
 - **`EntityCollection`** (`collection.go`) — chainable operations on entity sets: filtering (50+ built-in filters), pagination, concurrent iteration (`ForEachConcurrent`), field extraction, grouping, stats, and conversion to migration operations.
 
@@ -56,7 +56,7 @@ Single library package (`commanderclient/`) with a thin CLI entry point (`main.g
 
 ### Configuration
 
-Environment variables: `CONTENTFUL_CMAKEY`, `CONTENTFUL_SPACE_ID`, `CONTENTFUL_ENVIRONMENT`, `CONTENTFUL_VERBOSE`. Loaded via `LoadConfigFromEnv()` in `utils.go`.
+Environment variables: `CONTENTFUL_CMAKEY`, `CONTENTFUL_CDAKEY` (optional, enables CDA views), `CONTENTFUL_SPACE_ID`, `CONTENTFUL_ENVIRONMENT`, `CONTENTFUL_VERBOSE`. Loaded via `LoadConfigFromEnv()` in `utils.go`. `Config.SkipAssets` is code-only (no env var).
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -14,16 +14,18 @@ A Go library for Contentful migrations that provides a high-level interface for 
 
 - **Unified Entity Interface**: Work with both Contentful entries and assets through a common interface
 - **Space Model Caching**: Load and cache entire space models for efficient operations
+- **Dual CMA/CDA Loading**: Load management (CMA) and delivery (CDA) views side-by-side for diff-style comparisons
 - **Locale-Aware Operations**: Native support for Contentful's localization system with locale-specific field access
 - **Type-Safe Field Access**: Specialized methods for different field types (string, float64, bool, references)
 - **Reference Resolution**: Direct access to referenced entities with automatic broken reference handling
 - **Asset-Specific Methods**: Dedicated methods for asset title, description, and file access
-- **Flexible Filtering**: Filter entities by content type, publication status, timestamps, and custom criteria
+- **Flexible Filtering**: Filter entities by content type, publication status, CDA availability, timestamps, and custom criteria
 - **Collection Operations**: Chain operations like filtering, mapping, grouping, and reducing
 - **Migration Execution**: Execute batch operations with dry-run support, concurrent execution, and comprehensive error handling
 - **DeepL Translation**: Built-in DeepL API integration for automated field translation with cost tracking
 - **Concurrent Loading**: Parallel loading of entries and assets for faster space initialization
-- **Configuration Management**: Load configuration from environment variables or `.contentfulrc.json` files
+- **Selective Loading**: Skip asset loading with `SkipAssets` to save time and bandwidth when only entries are needed
+- **Configuration Management**: Load configuration from environment variables
 - **Portable Design**: Only depends on `github.com/foomo/contentful` and standard library
 
 ## Quick Start
@@ -102,6 +104,10 @@ type Entity interface {
     GetDescription(locale Locale) string
     GetFile(locale Locale) *contentful.File
 
+    // CDA (Content Delivery API) view
+    HasCDAView() bool       // true if a published CDA snapshot is attached
+    CDAView() Entity        // the published view, or nil
+
     // Utility methods
     SetFieldValue(fieldName string, locale Locale, value any)
     GetSys() *contentful.Sys
@@ -122,6 +128,38 @@ The library provides accurate publishing status detection based on Contentful's 
 entity := client.GetEntity("some-id")
 status := entity.GetPublishingStatus() // "draft", "published", or "changed"
 isPublished := entity.IsPublished()     // true only if status == "published"
+```
+
+### CDA Views
+
+When a CDA (Content Delivery API) key is provided, the client loads published snapshots alongside the CMA (management) data and attaches them to each entity. This lets you compare draft vs. published content without extra API calls.
+
+```go
+// Enable CDA views via config
+config := commanderclient.LoadConfigFromEnv() // reads CONTENTFUL_CDAKEY
+// or set manually: config.CDAToken = "your-cda-key"
+
+client, logger, err := commanderclient.Init(config)
+
+// Check CDA availability on the client
+if client.HasCDA() {
+    log.Println("CDA views are available")
+}
+
+// Access the published view of any entity
+entity, _ := client.GetEntity("some-id")
+if entity.HasCDAView() {
+    published := entity.CDAView()
+    draftTitle := entity.GetFieldValueAsString("title", locale)
+    liveTitle := published.GetFieldValueAsString("title", locale)
+    if draftTitle != liveTitle {
+        log.Printf("Title changed: %q -> %q", liveTitle, draftTitle)
+    }
+}
+
+// Filter entities by CDA availability
+withCDA := client.FilterEntities(commanderclient.FilterHasCDAView())   // has published version
+noCDA := client.FilterEntities(commanderclient.FilterNoCDAView())      // draft-only
 ```
 
 The `MigrationClient` provides the main interface for working with Contentful spaces:
@@ -653,6 +691,10 @@ commanderclient.FilterByType("Entry")  // or "Asset"
 commanderclient.FilterPublished()
 commanderclient.FilterDrafts()
 
+// CDA view filters (requires CDA key)
+commanderclient.FilterHasCDAView()    // has a published CDA snapshot
+commanderclient.FilterNoCDAView()     // draft-only or no CDA key
+
 // Timestamp filters
 commanderclient.FilterByCreatedAfter(time)
 commanderclient.FilterByUpdatedAfter(time)
@@ -677,9 +719,11 @@ config := commanderclient.LoadConfigFromEnv()
 // Or create custom config
 config := &commanderclient.Config{
     CMAToken:    "your-cma-key",
+    CDAToken:    "your-cda-key",  // optional — enables CDA views
     SpaceID:     "your-space-id",
     Environment: "master",
     Verbose:     true,
+    SkipAssets:  false, // set true to skip loading assets entirely
 }
 
 // Initialize ready-to-use client with logger and loaded space model
@@ -691,10 +735,14 @@ if err != nil {
 
 Environment variables:
 - `CONTENTFUL_CMAKEY`: CMA API key (mandatory)
+- `CONTENTFUL_CDAKEY`: CDA API key (optional — enables CDA views on entities)
 - `CONTENTFUL_SPACE_ID`: Space ID (mandatory)
 - `CONTENTFUL_ENVIRONMENT`: Environment (default: "dev")
 - `CONTENTFUL_VERBOSE`: Enable verbose logging
 - `DEEPL_API_KEY`: DeepL API key (required for translation features)
+
+Code-only config options (not loaded from env):
+- `Config.SkipAssets`: Skip loading assets to save time and bandwidth when only entries are needed
 
 ## Example Usage
 
@@ -785,7 +833,8 @@ log.Printf("Processed %d entities with %d errors",
 ## Performance Considerations
 
 - The library loads entire space models into memory for efficient operations
-- **Concurrent loading**: Entries and assets are loaded in parallel for faster initialization
+- **Concurrent loading**: Entries and assets are loaded in parallel for faster initialization. When a CDA key is provided, CDA views are loaded in a second concurrent phase after CMA data
+- **Skip assets**: Set `Config.SkipAssets = true` to skip asset loading entirely — useful for entry-only migrations where assets are irrelevant
 - **Concurrent batch execution**: `ExecuteBatch` runs operations concurrently (default: 3 parallel API calls, configurable via `client.SetConcurrency(n)`)
 - Use appropriate batch sizes for large operations
 - Consider using dry-run mode for testing

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A Go library for Contentful migrations that provides a high-level interface for 
 - **Type-Safe Field Access**: Specialized methods for different field types (string, float64, bool, references)
 - **Reference Resolution**: Direct access to referenced entities with automatic broken reference handling
 - **Asset-Specific Methods**: Dedicated methods for asset title, description, and file access
+- **Null/Empty Field Detection**: First-class `IsFieldNullOrEmpty` check for nil, empty string, empty map, and empty slice values
 - **Flexible Filtering**: Filter entities by content type, publication status, CDA availability, timestamps, and custom criteria
 - **Collection Operations**: Chain operations like filtering, mapping, grouping, and reducing
 - **Migration Execution**: Execute batch operations with dry-run support, concurrent execution, and comprehensive error handling
@@ -98,6 +99,7 @@ type Entity interface {
 
     // Advanced field access
     GetFieldValueInto(fieldName string, locale Locale, target any) error
+    IsFieldNullOrEmpty(fieldName string, locale Locale) bool
 
     // Entity-specific methods
     GetTitle(locale Locale) string
@@ -292,6 +294,20 @@ allParents := entryEntity.GetParents(nil)
 
 // Filter parents by content type
 pageParents := entryEntity.GetParents([]string{"page", "landingPage"})
+```
+
+### Null/Empty Check
+
+```go
+// Check if a field value is nil, an empty string, an empty map, or an empty slice
+if entity.IsFieldNullOrEmpty("description", commanderclient.Locale("en")) {
+    log.Println("Description is missing or empty")
+}
+
+// Works with assets too (checks title, description, file)
+if asset.IsFieldNullOrEmpty("file", commanderclient.Locale("de")) {
+    log.Println("No German file uploaded")
+}
 ```
 
 ### Advanced Field Access

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A Go library for Contentful migrations that provides a high-level interface for 
 - **Locale-Aware Operations**: Native support for Contentful's localization system with locale-specific field access
 - **Type-Safe Field Access**: Specialized methods for different field types (string, float64, bool, references)
 - **Reference Resolution**: Direct access to referenced entities with automatic broken reference handling
+- **Referrer Path Traversal**: Walk up the referrer chain to trace how an entity is reached, with stop conditions and cycle detection
 - **Asset-Specific Methods**: Dedicated methods for asset title, description, and file access
 - **Null/Empty Field Detection**: First-class `IsFieldNullOrEmpty` check for nil, empty string, empty map, and empty slice values
 - **Flexible Filtering**: Filter entities by content type, publication status, CDA availability, timestamps, and custom criteria
@@ -105,6 +106,10 @@ type Entity interface {
     GetTitle(locale Locale) string
     GetDescription(locale Locale) string
     GetFile(locale Locale) *contentful.File
+
+    // Graph traversal
+    GetParents(contentTypes []string) *EntityCollection               // direct referrers
+    GetReferrerPath(fieldNames []string, opts ...PathOption) ([]Entity, error) // full referrer chain (root → self)
 
     // CDA (Content Delivery API) view
     HasCDAView() bool       // true if a published CDA snapshot is attached
@@ -289,11 +294,46 @@ tagEntities.ForEach(func(tagEntity commanderclient.Entity) {
 
 // Reverse lookup: find all entities that reference this entry
 // Returns parents across all content types
-entryEntity := entity.(*commanderclient.EntryEntity)
-allParents := entryEntity.GetParents(nil)
+allParents := entity.GetParents(nil)
 
 // Filter parents by content type
-pageParents := entryEntity.GetParents([]string{"page", "landingPage"})
+pageParents := entity.GetParents([]string{"page", "landingPage"})
+```
+
+### Referrer Path Traversal
+
+Walk up the referrer chain through specific link fields to get the full path from root to a given entity. Useful for building breadcrumbs, validating content trees, or understanding how an entity is reached.
+
+```go
+// Get the full path from root to this entity, following "children" link fields
+path, err := article.GetReferrerPath([]string{"children"})
+// path = [page, section, article]
+
+// Stop at a specific content type (e.g. only care about section → leaf)
+path, err := article.GetReferrerPath([]string{"children"}, commanderclient.StopAtContentType("section"))
+// path = [section, article]
+
+// Stop at a specific entity ID
+path, err := article.GetReferrerPath([]string{"children"}, commanderclient.StopAtEntityID("section-42"))
+
+// Multiple field names — matches if any of the listed fields contain the reference
+path, err := asset.GetReferrerPath([]string{"hero", "image", "thumbnail"})
+```
+
+The method returns sentinel errors for two edge cases:
+
+```go
+// Multiple entities reference the same child through the searched fields
+_, err := entity.GetReferrerPath([]string{"children"})
+if errors.Is(err, commanderclient.ErrAmbiguousPath) {
+    // handle ambiguity
+}
+
+// A cycle is detected in the referrer chain
+_, err := entity.GetReferrerPath([]string{"children"})
+if errors.Is(err, commanderclient.ErrCircularReference) {
+    // handle cycle
+}
 ```
 
 ### Null/Empty Check

--- a/commanderclient/client.go
+++ b/commanderclient/client.go
@@ -16,6 +16,7 @@ import (
 // MigrationClient provides a high-level interface for Contentful migrations
 type MigrationClient struct {
 	cma         *contentful.Contentful
+	cda         *contentful.Contentful
 	spaceID     string
 	environment string
 	spaceModel  *SpaceModel
@@ -23,10 +24,11 @@ type MigrationClient struct {
 	cacheMu     sync.Mutex
 	stats       *MigrationStats
 	concurrency int
+	skipAssets  bool
 }
 
 // newMigrationClient creates a new migration client
-func newMigrationClient(cmaKey, spaceID, environment string) *MigrationClient {
+func newMigrationClient(cmaKey, cdaKey, spaceID, environment string) *MigrationClient {
 	if environment == "" {
 		environment = "dev"
 	}
@@ -34,7 +36,7 @@ func newMigrationClient(cmaKey, spaceID, environment string) *MigrationClient {
 	cma := contentful.NewCMA(cmaKey)
 	cma.Environment = environment
 
-	return &MigrationClient{
+	mc := &MigrationClient{
 		cma:         cma,
 		spaceID:     spaceID,
 		environment: environment,
@@ -44,6 +46,14 @@ func newMigrationClient(cmaKey, spaceID, environment string) *MigrationClient {
 		},
 		concurrency: 3,
 	}
+
+	if cdaKey != "" {
+		cda := contentful.NewCDA(cdaKey)
+		cda.Environment = environment
+		mc.cda = cda
+	}
+
+	return mc
 }
 
 // GetSpaceID returns the space ID
@@ -59,6 +69,16 @@ func (mc *MigrationClient) GetEnvironment() string {
 // GetCMA returns the underlying CMA client
 func (mc *MigrationClient) GetCMA() *contentful.Contentful {
 	return mc.cma
+}
+
+// HasCDA returns true if a CDA client is configured
+func (mc *MigrationClient) HasCDA() bool {
+	return mc.cda != nil
+}
+
+// GetCDA returns the underlying CDA client (nil when no CDA key is configured)
+func (mc *MigrationClient) GetCDA() *contentful.Contentful {
+	return mc.cda
 }
 
 // GetStats returns migration statistics
@@ -96,14 +116,32 @@ func (mc *MigrationClient) LoadSpaceModel(ctx context.Context, logger *Logger) e
 		}
 		return nil
 	})
-	g.Go(func() error {
-		if err := mc.loadAssets(gCtx, spaceModel, logger); err != nil {
-			return fmt.Errorf("failed to load assets: %w", err)
-		}
-		return nil
-	})
+	if !mc.skipAssets {
+		g.Go(func() error {
+			if err := mc.loadAssets(gCtx, spaceModel, logger); err != nil {
+				return fmt.Errorf("failed to load assets: %w", err)
+			}
+			return nil
+		})
+	}
 	if err := g.Wait(); err != nil {
 		return err
+	}
+
+	// Load CDA views (must run after CMA phase — needs CMA entities to attach to)
+	if mc.cda != nil {
+		gCDA, gCDACtx := errgroup.WithContext(ctx)
+		gCDA.Go(func() error {
+			return mc.loadCDAEntries(gCDACtx, spaceModel, 512, logger)
+		})
+		if !mc.skipAssets {
+			gCDA.Go(func() error {
+				return mc.loadCDAAssets(gCDACtx, spaceModel, logger)
+			})
+		}
+		if err := gCDA.Wait(); err != nil {
+			return err
+		}
 	}
 
 	mc.spaceModel = spaceModel
@@ -199,7 +237,13 @@ func (mc *MigrationClient) RefreshEntity(ctx context.Context, id string) error {
 	// Try to get as entry first
 	entry, err := mc.cma.Entries.Get(ctx, mc.spaceID, id)
 	if err == nil {
-		entity := &EntryEntity{Entry: entry}
+		entity := &EntryEntity{Entry: entry, Client: mc}
+		// Fetch CDA view if available (failure is silent — entity may be draft)
+		if mc.cda != nil {
+			if cdaEntry, cdaErr := mc.cda.Entries.Get(ctx, mc.spaceID, id); cdaErr == nil {
+				entity.cdaView = &EntryEntity{Entry: cdaEntry, Client: mc}
+			}
+		}
 		mc.cacheMu.Lock()
 		mc.cache[id] = entity
 		if mc.spaceModel != nil {
@@ -212,7 +256,13 @@ func (mc *MigrationClient) RefreshEntity(ctx context.Context, id string) error {
 	// Try to get as asset
 	asset, err := mc.cma.Assets.Get(ctx, mc.spaceID, id)
 	if err == nil {
-		entity := &AssetEntity{Asset: asset}
+		entity := &AssetEntity{Asset: asset, Client: mc}
+		// Fetch CDA view if available
+		if mc.cda != nil {
+			if cdaAsset, cdaErr := mc.cda.Assets.Get(ctx, mc.spaceID, id); cdaErr == nil {
+				entity.cdaView = &AssetEntity{Asset: cdaAsset, Client: mc}
+			}
+		}
 		mc.cacheMu.Lock()
 		mc.cache[id] = entity
 		if mc.spaceModel != nil {

--- a/commanderclient/collection.go
+++ b/commanderclient/collection.go
@@ -489,6 +489,20 @@ func FilterByFieldExistsWithLocale(fieldName string, locale Locale) EntityFilter
 	}
 }
 
+// FilterHasCDAView returns a filter for entities that have a CDA view attached
+func FilterHasCDAView() EntityFilter {
+	return func(entity Entity) bool {
+		return entity.HasCDAView()
+	}
+}
+
+// FilterNoCDAView returns a filter for entities without a CDA view (draft-only or no CDA key configured)
+func FilterNoCDAView() EntityFilter {
+	return func(entity Entity) bool {
+		return !entity.HasCDAView()
+	}
+}
+
 // FilterByLocaleAvailability returns a filter for entities that have content in specific locales
 func FilterByLocaleAvailability(requiredLocales []Locale) EntityFilter {
 	return func(entity Entity) bool {

--- a/commanderclient/entities.go
+++ b/commanderclient/entities.go
@@ -266,6 +266,14 @@ func (ee *EntryEntity) IsAsset() bool {
 	return false
 }
 
+func (ee *EntryEntity) HasCDAView() bool {
+	return ee.cdaView != nil
+}
+
+func (ee *EntryEntity) CDAView() Entity {
+	return ee.cdaView
+}
+
 // GetParents returns all entities that reference this entry.
 // If contentTypes is non-nil, only parents matching those content types are returned.
 func (ee *EntryEntity) GetParents(contentTypes []string) *EntityCollection {
@@ -502,6 +510,14 @@ func (ae *AssetEntity) IsEntry() bool {
 
 func (ae *AssetEntity) IsAsset() bool {
 	return true
+}
+
+func (ae *AssetEntity) HasCDAView() bool {
+	return ae.cdaView != nil
+}
+
+func (ae *AssetEntity) CDAView() Entity {
+	return ae.cdaView
 }
 
 // GetParents returns all entities that reference this asset.

--- a/commanderclient/entities.go
+++ b/commanderclient/entities.go
@@ -2,11 +2,119 @@ package commanderclient
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/foomo/contentful"
 )
+
+var (
+	// ErrCircularReference is returned when a cycle is detected while walking the referrer path.
+	ErrCircularReference = errors.New("circular reference detected in referrer path")
+	// ErrAmbiguousPath is returned when multiple referrers are found at one step of the referrer path.
+	ErrAmbiguousPath = errors.New("ambiguous referrer path: multiple referrers found at one step")
+)
+
+// PathOption configures the behavior of GetReferrerPath.
+type PathOption func(*pathConfig)
+
+type pathConfig struct {
+	stopAtEntityID    string
+	stopAtContentType string
+}
+
+// StopAtEntityID makes GetReferrerPath stop walking when the entity with the given ID is reached.
+func StopAtEntityID(id string) PathOption {
+	return func(cfg *pathConfig) {
+		cfg.stopAtEntityID = id
+	}
+}
+
+// StopAtContentType makes GetReferrerPath stop walking when an entity with the given content type is reached.
+func StopAtContentType(ct string) PathOption {
+	return func(cfg *pathConfig) {
+		cfg.stopAtContentType = ct
+	}
+}
+
+// entityReferencesIDViaFields checks whether any of the specified fields (across all locales) reference the given ID.
+func entityReferencesIDViaFields(fields map[string]any, targetID string, fieldNames []string) bool {
+	for _, name := range fieldNames {
+		fieldValue, ok := fields[name]
+		if !ok {
+			continue
+		}
+		localeMap, ok := fieldValue.(map[string]any)
+		if !ok {
+			continue
+		}
+		for _, localeValue := range localeMap {
+			if valueReferencesID(localeValue, targetID) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// getReferrerPath walks up the referrer chain through the specified fields and returns the path from root to self.
+func getReferrerPath(client *MigrationClient, startID string, startEntity Entity, fieldNames []string, opts ...PathOption) ([]Entity, error) {
+	if client == nil || len(fieldNames) == 0 {
+		return []Entity{startEntity}, nil
+	}
+
+	var cfg pathConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	path := []Entity{startEntity}
+	visited := map[string]struct{}{startID: {}}
+	currentID := startID
+
+	for {
+		var referrers []Entity
+		for _, entity := range client.cache {
+			if entity.GetID() == currentID {
+				continue
+			}
+			if entityReferencesIDViaFields(entity.GetFields(), currentID, fieldNames) {
+				referrers = append(referrers, entity)
+			}
+		}
+
+		if len(referrers) == 0 {
+			break
+		}
+		if len(referrers) > 1 {
+			return nil, ErrAmbiguousPath
+		}
+
+		referrer := referrers[0]
+		referrerID := referrer.GetID()
+
+		if _, seen := visited[referrerID]; seen {
+			return nil, ErrCircularReference
+		}
+
+		visited[referrerID] = struct{}{}
+		path = append(path, referrer)
+
+		if cfg.stopAtEntityID != "" && referrerID == cfg.stopAtEntityID {
+			break
+		}
+		if cfg.stopAtContentType != "" && referrer.GetContentType() == cfg.stopAtContentType {
+			break
+		}
+
+		currentID = referrerID
+	}
+
+	slices.Reverse(path)
+	return path, nil
+}
 
 func isNullOrEmpty(value any) bool {
 	if value == nil {
@@ -293,6 +401,11 @@ func (ee *EntryEntity) CDAView() Entity {
 	return ee.cdaView
 }
 
+// GetReferrerPath walks up the referrer chain through the specified fields and returns the path from root to self.
+func (ee *EntryEntity) GetReferrerPath(fieldNames []string, opts ...PathOption) ([]Entity, error) {
+	return getReferrerPath(ee.Client, ee.GetID(), ee, fieldNames, opts...)
+}
+
 // GetParents returns all entities that reference this entry.
 // If contentTypes is non-nil, only parents matching those content types are returned.
 func (ee *EntryEntity) GetParents(contentTypes []string) *EntityCollection {
@@ -550,6 +663,11 @@ func (ae *AssetEntity) HasCDAView() bool {
 
 func (ae *AssetEntity) CDAView() Entity {
 	return ae.cdaView
+}
+
+// GetReferrerPath walks up the referrer chain through the specified fields and returns the path from root to self.
+func (ae *AssetEntity) GetReferrerPath(fieldNames []string, opts ...PathOption) ([]Entity, error) {
+	return getReferrerPath(ae.Client, ae.GetID(), ae, fieldNames, opts...)
 }
 
 // GetParents returns all entities that reference this asset.

--- a/commanderclient/entities.go
+++ b/commanderclient/entities.go
@@ -8,6 +8,21 @@ import (
 	"github.com/foomo/contentful"
 )
 
+func isNullOrEmpty(value any) bool {
+	if value == nil {
+		return true
+	}
+	switch v := value.(type) {
+	case string:
+		return v == ""
+	case map[string]any:
+		return len(v) == 0
+	case []any:
+		return len(v) == 0
+	}
+	return false
+}
+
 // EntryEntity implementation
 
 func (ee *EntryEntity) GetID() string {
@@ -232,6 +247,10 @@ func (ee *EntryEntity) convertToReference(value any) *contentful.Entry {
 		}
 	}
 	return nil
+}
+
+func (ee *EntryEntity) IsFieldNullOrEmpty(fieldName string, locale Locale) bool {
+	return isNullOrEmpty(ee.GetFieldValue(fieldName, locale))
 }
 
 func (ee *EntryEntity) SetFieldValue(fieldName string, locale Locale, value any) {
@@ -473,6 +492,19 @@ func (ae *AssetEntity) GetFile(locale Locale) *contentful.File {
 		}
 	}
 	return nil
+}
+
+func (ae *AssetEntity) IsFieldNullOrEmpty(fieldName string, locale Locale) bool {
+	switch fieldName {
+	case "title":
+		return ae.GetTitle(locale) == ""
+	case "description":
+		return ae.GetDescription(locale) == ""
+	case "file":
+		return ae.GetFile(locale) == nil
+	default:
+		return true
+	}
 }
 
 func (ae *AssetEntity) SetFieldValue(fieldName string, locale Locale, value any) {

--- a/commanderclient/loader.go
+++ b/commanderclient/loader.go
@@ -51,3 +51,48 @@ func (mc *MigrationClient) loadAssets(ctx context.Context, spaceModel *SpaceMode
 	logger.Info("Loaded %d assets", mc.stats.ProcessedAssets)
 	return nil
 }
+
+// loadCDAEntries loads all published entries via CDA and attaches them as cdaView on matching CMA entities.
+func (mc *MigrationClient) loadCDAEntries(ctx context.Context, spaceModel *SpaceModel, limit uint16, logger *Logger) error {
+	if limit == 0 {
+		limit = 512
+	}
+	entriesCollection := mc.cda.Entries.List(ctx, mc.spaceID)
+	entriesCollection.Query.Locale("*").Include(0).Limit(limit)
+	entries, err := entriesCollection.GetAll()
+	if err != nil {
+		return err
+	}
+	matched := 0
+	for _, entry := range entries.Items {
+		if cmaEntity, ok := spaceModel.Entries[entry.Sys.ID]; ok {
+			if ee, ok := cmaEntity.(*EntryEntity); ok {
+				ee.cdaView = &EntryEntity{Entry: &entry, Client: mc}
+				matched++
+			}
+		}
+	}
+	logger.Info("Loaded %d CDA entries (%d matched CMA entries)", len(entries.Items), matched)
+	return nil
+}
+
+// loadCDAAssets loads all published assets via CDA and attaches them as cdaView on matching CMA assets.
+func (mc *MigrationClient) loadCDAAssets(ctx context.Context, spaceModel *SpaceModel, logger *Logger) error {
+	assetsCollection := mc.cda.Assets.List(ctx, mc.spaceID)
+	assetsCollection.Query.Locale("*").Limit(1000)
+	assets, err := assetsCollection.GetAll()
+	if err != nil {
+		return err
+	}
+	matched := 0
+	for _, asset := range assets.Items {
+		if cmaEntity, ok := spaceModel.Assets[asset.Sys.ID]; ok {
+			if ae, ok := cmaEntity.(*AssetEntity); ok {
+				ae.cdaView = &AssetEntity{Asset: &asset, Client: mc}
+				matched++
+			}
+		}
+	}
+	logger.Info("Loaded %d CDA assets (%d matched CMA assets)", len(assets.Items), matched)
+	return nil
+}

--- a/commanderclient/migrationlib_test.go
+++ b/commanderclient/migrationlib_test.go
@@ -798,3 +798,119 @@ func TestCDAView(t *testing.T) {
 		}
 	})
 }
+
+func TestIsFieldNullOrEmpty(t *testing.T) {
+	t.Run("entry entity", func(t *testing.T) {
+		entry := &EntryEntity{
+			Entry: &contentful.Entry{
+				Sys: &contentful.Sys{
+					ID:      "test-entry",
+					Version: 1,
+					ContentType: &contentful.ContentType{
+						Sys: &contentful.Sys{ID: "article"},
+					},
+				},
+				Fields: map[string]any{
+					"title": map[string]any{
+						"en-US": "Hello",
+						"de-DE": "",
+					},
+					"body": map[string]any{
+						"en-US": map[string]any{},
+					},
+					"tags": map[string]any{
+						"en-US": []any{},
+						"de-DE": []any{"tag1"},
+					},
+				},
+			},
+		}
+
+		// nil field (field doesn't exist)
+		if !entry.IsFieldNullOrEmpty("nonexistent", "en-US") {
+			t.Error("Expected nonexistent field to be null or empty")
+		}
+
+		// non-empty string
+		if entry.IsFieldNullOrEmpty("title", "en-US") {
+			t.Error("Expected non-empty title to not be null or empty")
+		}
+
+		// empty string
+		if !entry.IsFieldNullOrEmpty("title", "de-DE") {
+			t.Error("Expected empty string title to be null or empty")
+		}
+
+		// nil locale (locale doesn't exist)
+		if !entry.IsFieldNullOrEmpty("title", "fr-FR") {
+			t.Error("Expected missing locale to be null or empty")
+		}
+
+		// empty map
+		if !entry.IsFieldNullOrEmpty("body", "en-US") {
+			t.Error("Expected empty map to be null or empty")
+		}
+
+		// empty slice
+		if !entry.IsFieldNullOrEmpty("tags", "en-US") {
+			t.Error("Expected empty slice to be null or empty")
+		}
+
+		// non-empty slice
+		if entry.IsFieldNullOrEmpty("tags", "de-DE") {
+			t.Error("Expected non-empty slice to not be null or empty")
+		}
+	})
+
+	t.Run("asset entity", func(t *testing.T) {
+		asset := &AssetEntity{
+			Asset: &contentful.Asset{
+				Sys: &contentful.Sys{
+					ID:      "test-asset",
+					Version: 1,
+				},
+				Fields: &contentful.FileFields{
+					Title: map[string]string{
+						"en-US": "My Asset",
+					},
+					Description: map[string]string{
+						"en-US": "",
+					},
+					File: map[string]*contentful.File{
+						"en-US": {URL: "https://example.com/file.png"},
+					},
+				},
+			},
+		}
+
+		// non-empty title
+		if asset.IsFieldNullOrEmpty("title", "en-US") {
+			t.Error("Expected non-empty title to not be null or empty")
+		}
+
+		// missing locale for title
+		if !asset.IsFieldNullOrEmpty("title", "de-DE") {
+			t.Error("Expected missing locale title to be null or empty")
+		}
+
+		// empty description
+		if !asset.IsFieldNullOrEmpty("description", "en-US") {
+			t.Error("Expected empty description to be null or empty")
+		}
+
+		// non-nil file
+		if asset.IsFieldNullOrEmpty("file", "en-US") {
+			t.Error("Expected non-nil file to not be null or empty")
+		}
+
+		// missing locale for file
+		if !asset.IsFieldNullOrEmpty("file", "de-DE") {
+			t.Error("Expected missing locale file to be null or empty")
+		}
+
+		// unknown field
+		if !asset.IsFieldNullOrEmpty("unknown", "en-US") {
+			t.Error("Expected unknown field to be null or empty")
+		}
+	})
+}

--- a/commanderclient/migrationlib_test.go
+++ b/commanderclient/migrationlib_test.go
@@ -230,7 +230,7 @@ func TestEntityCollection(t *testing.T) {
 
 func TestMigrationClient(t *testing.T) {
 	// Test client creation
-	client := newMigrationClient("test-key", "test-space", "master")
+	client := newMigrationClient("test-key", "", "test-space", "master")
 
 	if client.GetSpaceID() != "test-space" {
 		t.Errorf("Expected space ID 'test-space', got '%s'", client.GetSpaceID())
@@ -318,7 +318,7 @@ func TestFilters(t *testing.T) {
 }
 
 func TestGetParents(t *testing.T) {
-	client := newMigrationClient("test-key", "test-space", "master")
+	client := newMigrationClient("test-key", "", "test-space", "master")
 
 	// Target entry — the one we'll look for parents of
 	target := &EntryEntity{
@@ -563,4 +563,238 @@ func TestPublishingStatus(t *testing.T) {
 	if changedEntry.IsPublished() {
 		t.Error("Expected changed entry to not be published")
 	}
+}
+
+func TestCDAView(t *testing.T) {
+	t.Run("entry with CDA view", func(t *testing.T) {
+		cdaEntry := &EntryEntity{
+			Entry: &contentful.Entry{
+				Sys: &contentful.Sys{
+					ID:               "entry-1",
+					Version:          2,
+					PublishedVersion: 1,
+					ContentType: &contentful.ContentType{
+						Sys: &contentful.Sys{ID: "article"},
+					},
+				},
+				Fields: map[string]any{
+					"title": map[string]any{
+						"en-US": "Published Title",
+					},
+				},
+			},
+		}
+
+		cmaEntry := &EntryEntity{
+			Entry: &contentful.Entry{
+				Sys: &contentful.Sys{
+					ID:               "entry-1",
+					Version:          3,
+					PublishedVersion: 1,
+					ContentType: &contentful.ContentType{
+						Sys: &contentful.Sys{ID: "article"},
+					},
+				},
+				Fields: map[string]any{
+					"title": map[string]any{
+						"en-US": "Draft Title (changed)",
+					},
+				},
+			},
+			cdaView: cdaEntry,
+		}
+
+		if !cmaEntry.HasCDAView() {
+			t.Error("Expected HasCDAView() to be true")
+		}
+
+		view := cmaEntry.CDAView()
+		if view == nil {
+			t.Fatal("Expected CDAView() to return non-nil entity")
+		}
+
+		// Compare field values between CMA and CDA views
+		cmaTitle := cmaEntry.GetFieldValueAsString("title", "en-US")
+		cdaTitle := view.GetFieldValueAsString("title", "en-US")
+		if cmaTitle != "Draft Title (changed)" {
+			t.Errorf("Expected CMA title 'Draft Title (changed)', got '%s'", cmaTitle)
+		}
+		if cdaTitle != "Published Title" {
+			t.Errorf("Expected CDA title 'Published Title', got '%s'", cdaTitle)
+		}
+	})
+
+	t.Run("entry without CDA view (draft)", func(t *testing.T) {
+		draftEntry := &EntryEntity{
+			Entry: &contentful.Entry{
+				Sys: &contentful.Sys{
+					ID:               "draft-1",
+					Version:          1,
+					PublishedVersion: 0,
+					ContentType: &contentful.ContentType{
+						Sys: &contentful.Sys{ID: "article"},
+					},
+				},
+			},
+		}
+
+		if draftEntry.HasCDAView() {
+			t.Error("Expected HasCDAView() to be false for draft entry")
+		}
+		if draftEntry.CDAView() != nil {
+			t.Error("Expected CDAView() to be nil for draft entry")
+		}
+	})
+
+	t.Run("CDA view entity has no CDA view itself", func(t *testing.T) {
+		cdaEntry := &EntryEntity{
+			Entry: &contentful.Entry{
+				Sys: &contentful.Sys{
+					ID:               "entry-1",
+					Version:          2,
+					PublishedVersion: 1,
+					ContentType: &contentful.ContentType{
+						Sys: &contentful.Sys{ID: "article"},
+					},
+				},
+			},
+		}
+
+		cmaEntry := &EntryEntity{
+			Entry: &contentful.Entry{
+				Sys: &contentful.Sys{
+					ID:               "entry-1",
+					Version:          3,
+					PublishedVersion: 1,
+					ContentType: &contentful.ContentType{
+						Sys: &contentful.Sys{ID: "article"},
+					},
+				},
+			},
+			cdaView: cdaEntry,
+		}
+
+		// The CDA view itself should NOT have a CDA view (no recursion)
+		view := cmaEntry.CDAView()
+		if view.HasCDAView() {
+			t.Error("Expected CDA view entity's HasCDAView() to be false")
+		}
+		if view.CDAView() != nil {
+			t.Error("Expected CDA view entity's CDAView() to be nil")
+		}
+	})
+
+	t.Run("asset CDA view", func(t *testing.T) {
+		cdaAsset := &AssetEntity{
+			Asset: &contentful.Asset{
+				Sys: &contentful.Sys{
+					ID:               "asset-1",
+					Version:          2,
+					PublishedVersion: 1,
+				},
+				Fields: &contentful.FileFields{
+					Title: map[string]string{
+						"en-US": "Published Asset",
+					},
+				},
+			},
+		}
+
+		cmaAsset := &AssetEntity{
+			Asset: &contentful.Asset{
+				Sys: &contentful.Sys{
+					ID:               "asset-1",
+					Version:          3,
+					PublishedVersion: 1,
+				},
+				Fields: &contentful.FileFields{
+					Title: map[string]string{
+						"en-US": "Updated Asset",
+					},
+				},
+			},
+			cdaView: cdaAsset,
+		}
+
+		if !cmaAsset.HasCDAView() {
+			t.Error("Expected asset HasCDAView() to be true")
+		}
+
+		view := cmaAsset.CDAView()
+		if view == nil {
+			t.Fatal("Expected asset CDAView() to return non-nil entity")
+		}
+
+		cdaTitle := view.GetTitle("en-US")
+		cmaTitle := cmaAsset.GetTitle("en-US")
+		if cmaTitle != "Updated Asset" {
+			t.Errorf("Expected CMA asset title 'Updated Asset', got '%s'", cmaTitle)
+		}
+		if cdaTitle != "Published Asset" {
+			t.Errorf("Expected CDA asset title 'Published Asset', got '%s'", cdaTitle)
+		}
+
+		// Asset without CDA view
+		if cdaAsset.HasCDAView() {
+			t.Error("Expected CDA asset view's HasCDAView() to be false")
+		}
+	})
+
+	t.Run("FilterHasCDAView and FilterNoCDAView", func(t *testing.T) {
+		withCDA := &EntryEntity{
+			Entry: &contentful.Entry{
+				Sys: &contentful.Sys{
+					ID:               "with-cda",
+					Version:          2,
+					PublishedVersion: 1,
+					ContentType: &contentful.ContentType{
+						Sys: &contentful.Sys{ID: "article"},
+					},
+				},
+			},
+			cdaView: &EntryEntity{
+				Entry: &contentful.Entry{
+					Sys: &contentful.Sys{
+						ID:               "with-cda",
+						Version:          2,
+						PublishedVersion: 1,
+						ContentType: &contentful.ContentType{
+							Sys: &contentful.Sys{ID: "article"},
+						},
+					},
+				},
+			},
+		}
+
+		withoutCDA := &EntryEntity{
+			Entry: &contentful.Entry{
+				Sys: &contentful.Sys{
+					ID:               "without-cda",
+					Version:          1,
+					PublishedVersion: 0,
+					ContentType: &contentful.ContentType{
+						Sys: &contentful.Sys{ID: "article"},
+					},
+				},
+			},
+		}
+
+		collection := NewEntityCollection([]Entity{withCDA, withoutCDA})
+
+		hasCDA := collection.Filter(FilterHasCDAView())
+		if hasCDA.Count() != 1 {
+			t.Errorf("Expected 1 entity with CDA view, got %d", hasCDA.Count())
+		}
+		if hasCDA.Get()[0].GetID() != "with-cda" {
+			t.Errorf("Expected entity 'with-cda', got '%s'", hasCDA.Get()[0].GetID())
+		}
+
+		noCDA := collection.Filter(FilterNoCDAView())
+		if noCDA.Count() != 1 {
+			t.Errorf("Expected 1 entity without CDA view, got %d", noCDA.Count())
+		}
+		if noCDA.Get()[0].GetID() != "without-cda" {
+			t.Errorf("Expected entity 'without-cda', got '%s'", noCDA.Get()[0].GetID())
+		}
+	})
 }

--- a/commanderclient/migrationlib_test.go
+++ b/commanderclient/migrationlib_test.go
@@ -1,6 +1,7 @@
 package commanderclient
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/foomo/contentful"
@@ -503,6 +504,304 @@ func TestGetParents(t *testing.T) {
 
 		// Clean up
 		delete(client.cache, "parent-de")
+	})
+}
+
+func TestGetReferrerPath(t *testing.T) {
+	// Helper to build an entry entity with fields referencing other IDs.
+	makeEntry := func(client *MigrationClient, id, ct string, fields map[string]any) *EntryEntity {
+		return &EntryEntity{
+			Entry: &contentful.Entry{
+				Sys: &contentful.Sys{
+					ID:      id,
+					Version: 1,
+					ContentType: &contentful.ContentType{
+						Sys: &contentful.Sys{ID: ct},
+					},
+				},
+				Fields: fields,
+			},
+			Client: client,
+		}
+	}
+
+	linkRef := func(id string) map[string]any {
+		return map[string]any{"sys": map[string]any{"id": id, "type": "Link"}}
+	}
+
+	t.Run("linear path root -> mid -> leaf", func(t *testing.T) {
+		client := newMigrationClient("k", "", "s", "master")
+
+		root := makeEntry(client, "root", "page", map[string]any{
+			"children": map[string]any{"en-US": linkRef("mid")},
+		})
+		mid := makeEntry(client, "mid", "section", map[string]any{
+			"children": map[string]any{"en-US": linkRef("leaf")},
+		})
+		leaf := makeEntry(client, "leaf", "article", map[string]any{})
+
+		client.cache["root"] = root
+		client.cache["mid"] = mid
+		client.cache["leaf"] = leaf
+
+		path, err := leaf.GetReferrerPath([]string{"children"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(path) != 3 {
+			t.Fatalf("expected path length 3, got %d", len(path))
+		}
+		if path[0].GetID() != "root" || path[1].GetID() != "mid" || path[2].GetID() != "leaf" {
+			t.Errorf("expected [root, mid, leaf], got [%s, %s, %s]", path[0].GetID(), path[1].GetID(), path[2].GetID())
+		}
+	})
+
+	t.Run("no referrer returns self", func(t *testing.T) {
+		client := newMigrationClient("k", "", "s", "master")
+		alone := makeEntry(client, "alone", "article", map[string]any{})
+		client.cache["alone"] = alone
+
+		path, err := alone.GetReferrerPath([]string{"children"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(path) != 1 || path[0].GetID() != "alone" {
+			t.Errorf("expected [alone], got %v", path)
+		}
+	})
+
+	t.Run("field name filtering excludes non-matching referrers", func(t *testing.T) {
+		client := newMigrationClient("k", "", "s", "master")
+
+		// parent references child via "hero" field, but we only search "children"
+		parent := makeEntry(client, "parent", "page", map[string]any{
+			"hero": map[string]any{"en-US": linkRef("child")},
+		})
+		child := makeEntry(client, "child", "article", map[string]any{})
+
+		client.cache["parent"] = parent
+		client.cache["child"] = child
+
+		path, err := child.GetReferrerPath([]string{"children"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(path) != 1 {
+			t.Errorf("expected [child] (field filtered), got length %d", len(path))
+		}
+	})
+
+	t.Run("StopAtEntityID truncates path", func(t *testing.T) {
+		client := newMigrationClient("k", "", "s", "master")
+
+		root := makeEntry(client, "root", "page", map[string]any{
+			"children": map[string]any{"en-US": linkRef("mid")},
+		})
+		mid := makeEntry(client, "mid", "section", map[string]any{
+			"children": map[string]any{"en-US": linkRef("leaf")},
+		})
+		leaf := makeEntry(client, "leaf", "article", map[string]any{})
+
+		client.cache["root"] = root
+		client.cache["mid"] = mid
+		client.cache["leaf"] = leaf
+
+		path, err := leaf.GetReferrerPath([]string{"children"}, StopAtEntityID("mid"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(path) != 2 {
+			t.Fatalf("expected path length 2, got %d", len(path))
+		}
+		if path[0].GetID() != "mid" || path[1].GetID() != "leaf" {
+			t.Errorf("expected [mid, leaf], got [%s, %s]", path[0].GetID(), path[1].GetID())
+		}
+	})
+
+	t.Run("StopAtContentType truncates path", func(t *testing.T) {
+		client := newMigrationClient("k", "", "s", "master")
+
+		root := makeEntry(client, "root", "page", map[string]any{
+			"children": map[string]any{"en-US": linkRef("mid")},
+		})
+		mid := makeEntry(client, "mid", "section", map[string]any{
+			"children": map[string]any{"en-US": linkRef("leaf")},
+		})
+		leaf := makeEntry(client, "leaf", "article", map[string]any{})
+
+		client.cache["root"] = root
+		client.cache["mid"] = mid
+		client.cache["leaf"] = leaf
+
+		path, err := leaf.GetReferrerPath([]string{"children"}, StopAtContentType("section"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(path) != 2 {
+			t.Fatalf("expected path length 2, got %d", len(path))
+		}
+		if path[0].GetID() != "mid" || path[1].GetID() != "leaf" {
+			t.Errorf("expected [mid, leaf], got [%s, %s]", path[0].GetID(), path[1].GetID())
+		}
+	})
+
+	t.Run("multiple referrers returns ErrAmbiguousPath", func(t *testing.T) {
+		client := newMigrationClient("k", "", "s", "master")
+
+		p1 := makeEntry(client, "p1", "page", map[string]any{
+			"children": map[string]any{"en-US": linkRef("child")},
+		})
+		p2 := makeEntry(client, "p2", "page", map[string]any{
+			"children": map[string]any{"en-US": linkRef("child")},
+		})
+		child := makeEntry(client, "child", "article", map[string]any{})
+
+		client.cache["p1"] = p1
+		client.cache["p2"] = p2
+		client.cache["child"] = child
+
+		_, err := child.GetReferrerPath([]string{"children"})
+		if !errors.Is(err, ErrAmbiguousPath) {
+			t.Errorf("expected ErrAmbiguousPath, got %v", err)
+		}
+	})
+
+	t.Run("cycle returns ErrCircularReference", func(t *testing.T) {
+		client := newMigrationClient("k", "", "s", "master")
+
+		a := makeEntry(client, "a", "page", map[string]any{
+			"children": map[string]any{"en-US": linkRef("b")},
+		})
+		b := makeEntry(client, "b", "page", map[string]any{
+			"children": map[string]any{"en-US": linkRef("a")},
+		})
+
+		client.cache["a"] = a
+		client.cache["b"] = b
+
+		_, err := a.GetReferrerPath([]string{"children"})
+		if !errors.Is(err, ErrCircularReference) {
+			t.Errorf("expected ErrCircularReference, got %v", err)
+		}
+	})
+
+	t.Run("nil client returns self", func(t *testing.T) {
+		orphan := &EntryEntity{
+			Entry: &contentful.Entry{
+				Sys: &contentful.Sys{
+					ID:      "orphan",
+					Version: 1,
+					ContentType: &contentful.ContentType{
+						Sys: &contentful.Sys{ID: "article"},
+					},
+				},
+				Fields: map[string]any{},
+			},
+		}
+
+		path, err := orphan.GetReferrerPath([]string{"children"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(path) != 1 || path[0].GetID() != "orphan" {
+			t.Errorf("expected [orphan], got %v", path)
+		}
+	})
+
+	t.Run("empty fieldNames returns self", func(t *testing.T) {
+		client := newMigrationClient("k", "", "s", "master")
+		entry := makeEntry(client, "e1", "article", map[string]any{})
+		client.cache["e1"] = entry
+
+		path, err := entry.GetReferrerPath([]string{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(path) != 1 || path[0].GetID() != "e1" {
+			t.Errorf("expected [e1], got %v", path)
+		}
+	})
+
+	t.Run("asset as starting entity", func(t *testing.T) {
+		client := newMigrationClient("k", "", "s", "master")
+
+		parent := makeEntry(client, "parent", "page", map[string]any{
+			"image": map[string]any{"en-US": linkRef("asset-1")},
+		})
+		asset := &AssetEntity{
+			Asset: &contentful.Asset{
+				Sys: &contentful.Sys{
+					ID:      "asset-1",
+					Version: 1,
+				},
+				Fields: &contentful.FileFields{
+					Title: map[string]string{"en-US": "My Asset"},
+				},
+			},
+			Client: client,
+		}
+
+		client.cache["parent"] = parent
+		client.cache["asset-1"] = asset
+
+		path, err := asset.GetReferrerPath([]string{"image"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(path) != 2 {
+			t.Fatalf("expected path length 2, got %d", len(path))
+		}
+		if path[0].GetID() != "parent" || path[1].GetID() != "asset-1" {
+			t.Errorf("expected [parent, asset-1], got [%s, %s]", path[0].GetID(), path[1].GetID())
+		}
+	})
+
+	t.Run("reference in non-default locale still found", func(t *testing.T) {
+		client := newMigrationClient("k", "", "s", "master")
+
+		parent := makeEntry(client, "parent", "page", map[string]any{
+			"children": map[string]any{
+				"de-DE": linkRef("child"),
+			},
+		})
+		child := makeEntry(client, "child", "article", map[string]any{})
+
+		client.cache["parent"] = parent
+		client.cache["child"] = child
+
+		path, err := child.GetReferrerPath([]string{"children"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(path) != 2 {
+			t.Fatalf("expected path length 2, got %d", len(path))
+		}
+		if path[0].GetID() != "parent" {
+			t.Errorf("expected parent at index 0, got %s", path[0].GetID())
+		}
+	})
+
+	t.Run("stop condition entity not in chain returns full path", func(t *testing.T) {
+		client := newMigrationClient("k", "", "s", "master")
+
+		root := makeEntry(client, "root", "page", map[string]any{
+			"children": map[string]any{"en-US": linkRef("leaf")},
+		})
+		leaf := makeEntry(client, "leaf", "article", map[string]any{})
+
+		client.cache["root"] = root
+		client.cache["leaf"] = leaf
+
+		path, err := leaf.GetReferrerPath([]string{"children"}, StopAtEntityID("nonexistent"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(path) != 2 {
+			t.Fatalf("expected path length 2, got %d", len(path))
+		}
+		if path[0].GetID() != "root" || path[1].GetID() != "leaf" {
+			t.Errorf("expected [root, leaf], got [%s, %s]", path[0].GetID(), path[1].GetID())
+		}
 	})
 }
 

--- a/commanderclient/types.go
+++ b/commanderclient/types.go
@@ -126,6 +126,12 @@ type Entity interface {
 	// If contentTypes is non-nil, only parents matching those content types are returned.
 	GetParents(contentTypes []string) *EntityCollection
 
+	// GetReferrerPath walks up the referrer chain through the specified fields
+	// and returns the ordered path from root to self.
+	// Returns ErrAmbiguousPath if multiple referrers are found at any step.
+	// Returns ErrCircularReference if a cycle is detected.
+	GetReferrerPath(fieldNames []string, opts ...PathOption) ([]Entity, error)
+
 	// HasCDAView returns true if this entity has a CDA (Content Delivery API) view attached.
 	// The CDA view represents the published/live version of the entity.
 	HasCDAView() bool

--- a/commanderclient/types.go
+++ b/commanderclient/types.go
@@ -107,6 +107,9 @@ type Entity interface {
 	// GetFile returns the file information of the entity for the specified locale
 	GetFile(locale Locale) *contentful.File
 
+	// IsFieldNullOrEmpty returns true if the field value for the given locale is nil, an empty string, an empty map, or an empty slice
+	IsFieldNullOrEmpty(fieldName string, locale Locale) bool
+
 	// SetFieldValue sets the value of a field for a specific locale
 	SetFieldValue(fieldName string, locale Locale, value any)
 

--- a/commanderclient/types.go
+++ b/commanderclient/types.go
@@ -122,18 +122,28 @@ type Entity interface {
 	// GetParents returns all entities that reference this entity.
 	// If contentTypes is non-nil, only parents matching those content types are returned.
 	GetParents(contentTypes []string) *EntityCollection
+
+	// HasCDAView returns true if this entity has a CDA (Content Delivery API) view attached.
+	// The CDA view represents the published/live version of the entity.
+	HasCDAView() bool
+
+	// CDAView returns the CDA view of this entity, or nil if no CDA view is available.
+	// The CDA view is itself a full Entity with all standard methods.
+	CDAView() Entity
 }
 
 // EntryEntity wraps a Contentful entry
 type EntryEntity struct {
-	Entry  *contentful.Entry
-	Client *MigrationClient
+	Entry   *contentful.Entry
+	Client  *MigrationClient
+	cdaView Entity
 }
 
 // AssetEntity wraps a Contentful asset
 type AssetEntity struct {
-	Asset  *contentful.Asset
-	Client *MigrationClient
+	Asset   *contentful.Asset
+	Client  *MigrationClient
+	cdaView Entity
 }
 
 // EntityCollection represents a collection of entities with filtering capabilities

--- a/commanderclient/utils.go
+++ b/commanderclient/utils.go
@@ -10,15 +10,18 @@ import (
 // Config holds configuration for the migration library
 type Config struct {
 	CMAToken    string
+	CDAToken    string
 	SpaceID     string
 	Environment string
 	Verbose     bool
+	SkipAssets  bool
 }
 
 // LoadConfigFromEnv loads configuration from environment variables
 func LoadConfigFromEnv() *Config {
 	return &Config{
 		CMAToken:    os.Getenv("CONTENTFUL_CMAKEY"),
+		CDAToken:    os.Getenv("CONTENTFUL_CDAKEY"),
 		SpaceID:     os.Getenv("CONTENTFUL_SPACE_ID"),
 		Environment: getEnvOrDefault("CONTENTFUL_ENVIRONMENT", "dev"),
 		Verbose:     getEnvOrDefault("CONTENTFUL_VERBOSE", "true") == "true",
@@ -43,7 +46,8 @@ func Init(config *Config) (*MigrationClient, *Logger, error) {
 	}
 
 	// Create client
-	client := newMigrationClient(config.CMAToken, config.SpaceID, config.Environment)
+	client := newMigrationClient(config.CMAToken, config.CDAToken, config.SpaceID, config.Environment)
+	client.skipAssets = config.SkipAssets
 
 	// Create logger
 	logger := NewLogger(config.Verbose)


### PR DESCRIPTION
### Description

Add a CDA view of entitites, allowing for extraction of published field values and versions and comparison with the CMA version of the entities

### Type of Change

<!-- Check the relevant option -->

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance
- [x] ✅ Tests
- [ ] 🔧 Build/CI

### Related Issue

<!-- Link related issues: Fixes #123, Closes #456 -->

## Changes

- Add dual CMA/CDA loading: when a CDA key is provided, published snapshots are fetched and attached to each entity via HasCDAView() / CDAView(), enabling draft-vs-published comparisons without extra API calls
- Add Config.SkipAssets option to skip loading assets entirely, saving time and bandwidth for entry-only migrations
- Add FilterHasCDAView() and FilterNoCDAView() filters
- Add IsFieldNullOrEmpty()
- Add GetReferrerPath()
- Update README and CLAUDE.md with new features

### Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.

#### Notes

Full backward compatibility
