### PR TITLE
feat: cache updates, initial cache speed improvement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-# CLAUDE.md
+# AGENTS.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to AI coding agents when working with code in this repository.
 
 ## Project
 
@@ -42,7 +42,7 @@ Single library package (`commanderclient/`) with a thin CLI entry point (`main.g
 
 - **`Entity` interface** (`types.go`) — unified API over `EntryEntity` and `AssetEntity`. All field access is locale-aware with fallback support. Publishing status derived from version arithmetic: `draft` (PublishedVersion==0), `published` (Version-PublishedVersion==1), `changed` (>1).
 
-- **`MigrationClient`** (`client.go`) — wraps the foomo/contentful CMA SDK. Optionally pairs a CDA client for published-view access. `LoadSpaceModel()` fetches locales, content types, entries, and assets concurrently into a `SpaceModel` cache. Initial entry loading is split by content type with 3 workers, starts at 1000-entry pages, and halves the page size only for content types that hit Contentful response-size limits. `UpdateSpaceModel()` incrementally refreshes only recently changed entities (ordered by `-sys.updatedAt`, pages of 100, stops when reaching entities older than the previous update start). When a CDA key is provided, CDA views are loaded and attached to each entity (`entity.HasCDAView()`, `entity.CDAView()`). Set `Config.SkipAssets = true` to skip asset loading entirely. Provides entity lookups and filtering.
+- **`MigrationClient`** (`client.go`) — wraps the foomo/contentful CMA SDK. Optionally pairs a CDA client for published-view access. `LoadSpaceModel()` fetches locales, content types, entries, and assets concurrently into a `SpaceModel` cache. `UpdateSpaceModel()` incrementally refreshes only recently changed entities (ordered by `-sys.updatedAt`, pages of 100, stops when reaching entities older than the previous update start). When a CDA key is provided, CDA views are loaded and attached to each entity (`entity.HasCDAView()`, `entity.CDAView()`). Set `Config.SkipAssets = true` to skip asset loading entirely. Provides entity lookups and filtering.
 
 - **`EntityCollection`** (`collection.go`) — chainable operations on entity sets: filtering (50+ built-in filters), pagination, concurrent iteration (`ForEachConcurrent`), field extraction, grouping, stats, and conversion to migration operations.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ A Go library for Contentful migrations that provides a high-level interface for 
 - **Collection Operations**: Chain operations like filtering, mapping, grouping, and reducing
 - **Migration Execution**: Execute batch operations with dry-run support, concurrent execution, and comprehensive error handling
 - **DeepL Translation**: Built-in DeepL API integration for automated field translation with cost tracking
-- **Concurrent Loading**: Parallel loading of entries and assets for faster space initialization
+- **Incremental Cache Updates**: Efficiently refresh only recently changed entities using `UpdateSpaceModel`, ordered by `-sys.updatedAt`
+- **Concurrent Loading**: Parallel loading of entries and assets for faster space initialization, with adaptive per-content-type entry page sizes
 - **Selective Loading**: Skip asset loading with `SkipAssets` to save time and bandwidth when only entries are needed
 - **Configuration Management**: Load configuration from environment variables
 - **Portable Design**: Only depends on `github.com/foomo/contentful` and standard library
@@ -192,6 +193,30 @@ filtered := client.FilterEntities(
     commanderclient.FilterByUpdatedAfter(time.Now().AddDate(0, -1, 0)),
 )
 ```
+
+### Incremental Cache Updates
+
+After the initial `LoadSpaceModel`, you can efficiently refresh only the entities that have changed using `UpdateSpaceModel`. This avoids reloading the entire space and is ideal for long-running processes.
+
+```go
+client, logger, err := commanderclient.Init(config)
+if err != nil {
+    log.Fatal(err)
+}
+
+// ... perform work ...
+
+// Incrementally update the cache with only recently changed entities
+if err := client.UpdateSpaceModel(ctx, logger); err != nil {
+    log.Fatal(err)
+}
+```
+
+How it works:
+- The space model records the **start time** of each load/update (not the end time), so entities that changed during a previous load are caught on the next update
+- Entities are fetched in pages of 100, ordered by `-sys.updatedAt` (most recently changed first)
+- Pagination stops as soon as the oldest entity on a page is older than the previous update start time; entities with the exact cutoff timestamp are refreshed again to avoid missing rounded timestamps
+- Entries and assets are updated concurrently; CDA views are refreshed in a second phase if a CDA key is configured
 
 ### Collection Operations
 
@@ -889,7 +914,8 @@ log.Printf("Processed %d entities with %d errors",
 ## Performance Considerations
 
 - The library loads entire space models into memory for efficient operations
-- **Concurrent loading**: Entries and assets are loaded in parallel for faster initialization. When a CDA key is provided, CDA views are loaded in a second concurrent phase after CMA data
+- **Incremental updates**: Use `UpdateSpaceModel` instead of `LoadSpaceModel` to refresh only recently changed entities — significantly faster for large spaces with infrequent changes
+- **Concurrent loading**: Entries and assets are loaded in parallel for faster initialization. Initial entry loading is split by content type, starts with 1000-entry pages, and halves the page size only for content types that hit Contentful response-size limits. When a CDA key is provided, CDA views are loaded in a second concurrent phase after CMA data
 - **Skip assets**: Set `Config.SkipAssets = true` to skip asset loading entirely — useful for entry-only migrations where assets are irrelevant
 - **Concurrent batch execution**: `ExecuteBatch` runs operations concurrently (default: 3 parallel API calls, configurable via `client.SetConcurrency(n)`)
 - Use appropriate batch sizes for large operations

--- a/commanderclient/client.go
+++ b/commanderclient/client.go
@@ -21,7 +21,8 @@ type MigrationClient struct {
 	environment string
 	spaceModel  *SpaceModel
 	cache       map[string]Entity
-	cacheMu     sync.Mutex
+	cacheMu     sync.RWMutex
+	updateMu    sync.Mutex
 	stats       *MigrationStats
 	concurrency int
 	skipAssets  bool
@@ -89,6 +90,12 @@ func (mc *MigrationClient) GetStats() *MigrationStats {
 
 // LoadSpaceModel loads and caches the entire space model
 func (mc *MigrationClient) LoadSpaceModel(ctx context.Context, logger *Logger) error {
+	// Serialize with UpdateSpaceModel: a full reload and an incremental update
+	// must not run at the same time. Readers are not blocked during the load —
+	// the new model is built locally and swapped in atomically at the end.
+	mc.updateMu.Lock()
+	defer mc.updateMu.Unlock()
+
 	spaceModel := &SpaceModel{
 		SpaceID:      mc.spaceID,
 		Environment:  mc.environment,
@@ -111,7 +118,7 @@ func (mc *MigrationClient) LoadSpaceModel(ctx context.Context, logger *Logger) e
 	// Load entries and assets concurrently
 	g, gCtx := errgroup.WithContext(ctx)
 	g.Go(func() error {
-		if err := mc.loadEntries(gCtx, spaceModel, 512, logger); err != nil {
+		if err := mc.loadEntries(gCtx, spaceModel, 0, logger); err != nil {
 			return fmt.Errorf("failed to load entries: %w", err)
 		}
 		return nil
@@ -132,7 +139,7 @@ func (mc *MigrationClient) LoadSpaceModel(ctx context.Context, logger *Logger) e
 	if mc.cda != nil {
 		gCDA, gCDACtx := errgroup.WithContext(ctx)
 		gCDA.Go(func() error {
-			return mc.loadCDAEntries(gCDACtx, spaceModel, 512, logger)
+			return mc.loadCDAEntries(gCDACtx, spaceModel, 0, logger)
 		})
 		if !mc.skipAssets {
 			gCDA.Go(func() error {
@@ -144,76 +151,234 @@ func (mc *MigrationClient) LoadSpaceModel(ctx context.Context, logger *Logger) e
 		}
 	}
 
+	// Build the new cache locally, then swap it in under the write lock so
+	// concurrent readers never observe a partially populated cache.
+	newCache := make(map[string]Entity, len(spaceModel.Entries)+len(spaceModel.Assets))
+	maps.Copy(newCache, spaceModel.Entries)
+	maps.Copy(newCache, spaceModel.Assets)
+
+	mc.cacheMu.Lock()
 	mc.spaceModel = spaceModel
+	mc.cache = newCache
+	mc.stats.TotalEntities = len(newCache)
+	mc.cacheMu.Unlock()
 
-	// Update cache
-	mc.cache = make(map[string]Entity)
-	maps.Copy(mc.cache, spaceModel.Entries)
-	maps.Copy(mc.cache, spaceModel.Assets)
+	return nil
+}
 
-	mc.stats.TotalEntities = len(mc.cache)
+// UpdateSpaceModel incrementally updates the cached space model by fetching
+// only entities that have changed since the last LoadSpaceModel or UpdateSpaceModel call.
+// It uses order=-sys.updatedAt to load recently changed entities first and stops
+// when reaching entities older than the previous update start time.
+func (mc *MigrationClient) UpdateSpaceModel(ctx context.Context, logger *Logger) error {
+	// Serialize updates: concurrent calls would race on LastUpdated and on the
+	// cache map. A waiting caller proceeds with the freshly written cutoff.
+	mc.updateMu.Lock()
+	defer mc.updateMu.Unlock()
+
+	mc.cacheMu.RLock()
+	if mc.spaceModel == nil {
+		mc.cacheMu.RUnlock()
+		return fmt.Errorf("space model not loaded, call LoadSpaceModel first")
+	}
+	cutoff := mc.spaceModel.LastUpdated
+	mc.cacheMu.RUnlock()
+
+	updateStart := time.Now()
+
+	// Update entries and assets concurrently
+	var updatedEntries map[string]*EntryEntity
+	var updatedAssets map[string]*AssetEntity
+	g, gCtx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		entries, err := mc.updateEntries(gCtx, cutoff, logger)
+		if err != nil {
+			return err
+		}
+		updatedEntries = entries
+		return nil
+	})
+	if !mc.skipAssets {
+		g.Go(func() error {
+			assets, err := mc.updateAssets(gCtx, cutoff, logger)
+			if err != nil {
+				return err
+			}
+			updatedAssets = assets
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return err
+	}
+
+	// Update CDA views for changed entities
+	var updatedCDAEntries map[string]Entity
+	var updatedCDAAssets map[string]Entity
+	if mc.cda != nil {
+		gCDA, gCDACtx := errgroup.WithContext(ctx)
+		gCDA.Go(func() error {
+			entries, err := mc.updateCDAEntries(gCDACtx, cutoff, logger)
+			if err != nil {
+				return err
+			}
+			updatedCDAEntries = entries
+			return nil
+		})
+		if !mc.skipAssets {
+			gCDA.Go(func() error {
+				assets, err := mc.updateCDAAssets(gCDACtx, cutoff, logger)
+				if err != nil {
+					return err
+				}
+				updatedCDAAssets = assets
+				return nil
+			})
+		}
+		if err := gCDA.Wait(); err != nil {
+			return err
+		}
+	}
+
+	mc.cacheMu.Lock()
+	current := mc.spaceModel
+	spaceModel := &SpaceModel{
+		SpaceID:       current.SpaceID,
+		Environment:   current.Environment,
+		Locales:       append([]LocaleInfo(nil), current.Locales...),
+		DefaultLocale: current.DefaultLocale,
+		ContentTypes:  maps.Clone(current.ContentTypes),
+		Entries:       maps.Clone(current.Entries),
+		Assets:        maps.Clone(current.Assets),
+		LastUpdated:   updateStart,
+	}
+
+	for id, entity := range updatedEntries {
+		if previous, ok := spaceModel.Entries[id]; ok && entity.GetPublishingStatus() != StatusDraft {
+			entity.cdaView = previous.CDAView()
+		}
+		spaceModel.Entries[id] = entity
+	}
+	for id, entity := range updatedAssets {
+		if previous, ok := spaceModel.Assets[id]; ok && entity.GetPublishingStatus() != StatusDraft {
+			entity.cdaView = previous.CDAView()
+		}
+		spaceModel.Assets[id] = entity
+	}
+	for id, cdaView := range updatedCDAEntries {
+		if cmaEntity, ok := spaceModel.Entries[id]; ok {
+			if entryEntity, ok := cmaEntity.(*EntryEntity); ok {
+				spaceModel.Entries[id] = &EntryEntity{
+					Entry:   entryEntity.Entry,
+					Client:  entryEntity.Client,
+					cdaView: cdaView,
+				}
+			}
+		}
+	}
+	for id, cdaView := range updatedCDAAssets {
+		if cmaEntity, ok := spaceModel.Assets[id]; ok {
+			if assetEntity, ok := cmaEntity.(*AssetEntity); ok {
+				spaceModel.Assets[id] = &AssetEntity{
+					Asset:   assetEntity.Asset,
+					Client:  assetEntity.Client,
+					cdaView: cdaView,
+				}
+			}
+		}
+	}
+
+	newCache := make(map[string]Entity, len(spaceModel.Entries)+len(spaceModel.Assets))
+	maps.Copy(newCache, spaceModel.Entries)
+	maps.Copy(newCache, spaceModel.Assets)
+
+	mc.spaceModel = spaceModel
+	mc.cache = newCache
+	mc.stats.TotalEntities = len(newCache)
+	mc.cacheMu.Unlock()
 
 	return nil
 }
 
 // GetSpaceModel returns the cached space model
 func (mc *MigrationClient) GetSpaceModel() *SpaceModel {
+	mc.cacheMu.RLock()
+	defer mc.cacheMu.RUnlock()
 	return mc.spaceModel
 }
 
 // GetEntity retrieves an entity by ID from cache
 func (mc *MigrationClient) GetEntity(id string) (Entity, bool) {
+	mc.cacheMu.RLock()
+	defer mc.cacheMu.RUnlock()
 	entity, exists := mc.cache[id]
 	return entity, exists
 }
 
 // GetAllEntities returns all cached entities
 func (mc *MigrationClient) GetAllEntities() *EntityCollection {
+	mc.cacheMu.RLock()
 	entities := make([]Entity, 0, len(mc.cache))
 	for _, entity := range mc.cache {
 		entities = append(entities, entity)
 	}
+	mc.cacheMu.RUnlock()
 	return NewEntityCollection(entities)
 }
 
 // GetEntries returns all entry entities
 func (mc *MigrationClient) GetEntries() *EntityCollection {
+	mc.cacheMu.RLock()
 	var entries []Entity
 	for _, entity := range mc.cache {
 		if entity.GetType() == "Entry" {
 			entries = append(entries, entity)
 		}
 	}
+	mc.cacheMu.RUnlock()
 	return NewEntityCollection(entries)
 }
 
 // GetAssets returns all asset entities
 func (mc *MigrationClient) GetAssets() *EntityCollection {
+	mc.cacheMu.RLock()
 	var assets []Entity
 	for _, entity := range mc.cache {
 		if entity.GetType() == "Asset" {
 			assets = append(assets, entity)
 		}
 	}
+	mc.cacheMu.RUnlock()
 	return NewEntityCollection(assets)
 }
 
 // GetEntitiesByContentType returns entities filtered by content type
 func (mc *MigrationClient) GetEntitiesByContentType(contentType string) *EntityCollection {
+	mc.cacheMu.RLock()
 	var entities []Entity
 	for _, entity := range mc.cache {
 		if entity.GetType() == "Entry" && entity.GetContentType() == contentType {
 			entities = append(entities, entity)
 		}
 	}
+	mc.cacheMu.RUnlock()
 	return NewEntityCollection(entities)
 }
 
 // FilterEntities applies filters to entities and returns a collection
 func (mc *MigrationClient) FilterEntities(filters ...EntityFilter) *EntityCollection {
-	var filtered []Entity
-
+	// Snapshot the cache under the read lock, then evaluate filters without it.
+	// Filters are arbitrary callbacks that may call back into the client
+	// (e.g. GetEntity), so they must not run while the lock is held.
+	mc.cacheMu.RLock()
+	snapshot := make([]Entity, 0, len(mc.cache))
 	for _, entity := range mc.cache {
+		snapshot = append(snapshot, entity)
+	}
+	mc.cacheMu.RUnlock()
+
+	var filtered []Entity
+	for _, entity := range snapshot {
 		matches := true
 		for _, filter := range filters {
 			if !filter(entity) {
@@ -333,6 +498,8 @@ func (mc *MigrationClient) loadLocales(ctx context.Context, spaceModel *SpaceMod
 
 // GetLocales returns the locales for the space
 func (mc *MigrationClient) GetLocales() []LocaleInfo {
+	mc.cacheMu.RLock()
+	defer mc.cacheMu.RUnlock()
 	if mc.spaceModel == nil {
 		return []LocaleInfo{}
 	}
@@ -341,6 +508,8 @@ func (mc *MigrationClient) GetLocales() []LocaleInfo {
 
 // GetDefaultLocale returns the default locale for the space
 func (mc *MigrationClient) GetDefaultLocale() Locale {
+	mc.cacheMu.RLock()
+	defer mc.cacheMu.RUnlock()
 	if mc.spaceModel == nil {
 		return ""
 	}
@@ -349,6 +518,8 @@ func (mc *MigrationClient) GetDefaultLocale() Locale {
 
 // GetLocaleCodes returns all locale codes for the space
 func (mc *MigrationClient) GetLocaleCodes() []Locale {
+	mc.cacheMu.RLock()
+	defer mc.cacheMu.RUnlock()
 	if mc.spaceModel == nil {
 		return []Locale{}
 	}

--- a/commanderclient/loader.go
+++ b/commanderclient/loader.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	initialEntryPageSize        uint16 = 1000
-	initialEntryLoadConcurrency        = 3
+	initialEntryLoadConcurrency int    = 3
 )
 
 // loadContentTypes loads all content types from the space

--- a/commanderclient/loader.go
+++ b/commanderclient/loader.go
@@ -2,6 +2,20 @@ package commanderclient
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/foomo/contentful"
+	"golang.org/x/sync/errgroup"
+)
+
+const (
+	initialEntryPageSize        uint16 = 1000
+	initialEntryLoadConcurrency        = 3
 )
 
 // loadContentTypes loads all content types from the space
@@ -20,18 +34,16 @@ func (mc *MigrationClient) loadContentTypes(ctx context.Context, spaceModel *Spa
 // loadEntries loads all entries from the space
 func (mc *MigrationClient) loadEntries(ctx context.Context, spaceModel *SpaceModel, limit uint16, logger *Logger) error {
 	if limit == 0 {
-		limit = 512
+		limit = initialEntryPageSize
 	}
-	entriesCollection := mc.cma.Entries.List(ctx, mc.spaceID)
-	entriesCollection.Query.Locale("*").Include(0).Limit(limit)
-	entries, err := entriesCollection.GetAll()
+	entries, err := mc.loadEntriesByContentType(ctx, mc.cma, contentTypeIDs(spaceModel), limit, logger, "CMA")
 	if err != nil {
 		return err
 	}
-	for _, entry := range entries.Items {
+	for _, entry := range entries {
 		spaceModel.Entries[entry.Sys.ID] = &EntryEntity{Entry: &entry, Client: mc}
 	}
-	mc.stats.ProcessedEntries += len(entries.Items)
+	mc.stats.ProcessedEntries += len(entries)
 	logger.Info("Loaded %d entries", mc.stats.ProcessedEntries)
 	return nil
 }
@@ -55,16 +67,14 @@ func (mc *MigrationClient) loadAssets(ctx context.Context, spaceModel *SpaceMode
 // loadCDAEntries loads all published entries via CDA and attaches them as cdaView on matching CMA entities.
 func (mc *MigrationClient) loadCDAEntries(ctx context.Context, spaceModel *SpaceModel, limit uint16, logger *Logger) error {
 	if limit == 0 {
-		limit = 512
+		limit = initialEntryPageSize
 	}
-	entriesCollection := mc.cda.Entries.List(ctx, mc.spaceID)
-	entriesCollection.Query.Locale("*").Include(0).Limit(limit)
-	entries, err := entriesCollection.GetAll()
+	entries, err := mc.loadEntriesByContentType(ctx, mc.cda, contentTypeIDs(spaceModel), limit, logger, "CDA")
 	if err != nil {
 		return err
 	}
 	matched := 0
-	for _, entry := range entries.Items {
+	for _, entry := range entries {
 		if cmaEntity, ok := spaceModel.Entries[entry.Sys.ID]; ok {
 			if ee, ok := cmaEntity.(*EntryEntity); ok {
 				ee.cdaView = &EntryEntity{Entry: &entry, Client: mc}
@@ -72,8 +82,108 @@ func (mc *MigrationClient) loadCDAEntries(ctx context.Context, spaceModel *Space
 			}
 		}
 	}
-	logger.Info("Loaded %d CDA entries (%d matched CMA entries)", len(entries.Items), matched)
+	logger.Info("Loaded %d CDA entries (%d matched CMA entries)", len(entries), matched)
 	return nil
+}
+
+func (mc *MigrationClient) loadEntriesByContentType(ctx context.Context, client *contentful.Contentful, contentTypes []string, limit uint16, logger *Logger, source string) ([]contentful.Entry, error) {
+	if len(contentTypes) == 0 {
+		return nil, nil
+	}
+
+	contentTypeCh := make(chan string)
+	var mu sync.Mutex
+	var entries []contentful.Entry
+
+	g, gCtx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		defer close(contentTypeCh)
+		for _, contentType := range contentTypes {
+			select {
+			case contentTypeCh <- contentType:
+			case <-gCtx.Done():
+				return gCtx.Err()
+			}
+		}
+		return nil
+	})
+
+	for range initialEntryLoadConcurrency {
+		g.Go(func() error {
+			for contentType := range contentTypeCh {
+				contentTypeEntries, pageSize, err := mc.loadEntriesForContentType(gCtx, client, contentType, limit)
+				if err != nil {
+					return fmt.Errorf("failed to load %s entries for content type %s: %w", source, contentType, err)
+				}
+				mu.Lock()
+				entries = append(entries, contentTypeEntries...)
+				mu.Unlock()
+				logger.Info("Loaded %d %s entries for content type %s (page size %d)", len(contentTypeEntries), source, contentType, pageSize)
+			}
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+	return entries, nil
+}
+
+func (mc *MigrationClient) loadEntriesForContentType(ctx context.Context, client *contentful.Contentful, contentType string, limit uint16) ([]contentful.Entry, uint16, error) {
+	if limit == 0 {
+		limit = initialEntryPageSize
+	}
+
+	entries, err := mc.loadEntriesForContentTypeAtLimit(ctx, client, contentType, limit)
+	if err == nil {
+		return entries, limit, nil
+	}
+	if !isEntryPageSizeError(err) || limit <= 1 {
+		return nil, limit, err
+	}
+	return mc.loadEntriesForContentType(ctx, client, contentType, limit/2)
+}
+
+func (mc *MigrationClient) loadEntriesForContentTypeAtLimit(ctx context.Context, client *contentful.Contentful, contentType string, limit uint16) ([]contentful.Entry, error) {
+	col := client.Entries.List(ctx, mc.spaceID)
+	col.Query.ContentType(contentType).Locale("*").Include(0).Limit(limit)
+
+	var entries []contentful.Entry
+	for {
+		page, err := col.Next()
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, page.Items...)
+		if uint16(len(page.Items)) < limit {
+			break
+		}
+		col = page
+	}
+	return entries, nil
+}
+
+func contentTypeIDs(spaceModel *SpaceModel) []string {
+	contentTypes := make([]string, 0, len(spaceModel.ContentTypes))
+	for contentType := range spaceModel.ContentTypes {
+		contentTypes = append(contentTypes, contentType)
+	}
+	sort.Strings(contentTypes)
+	return contentTypes
+}
+
+func isEntryPageSizeError(err error) bool {
+	var contentfulErr contentful.ErrorResponse
+	if errors.As(err, &contentfulErr) && isEntryPageSizeErrorMessage(contentfulErr.Message) {
+		return true
+	}
+	return isEntryPageSizeErrorMessage(err.Error())
+}
+
+func isEntryPageSizeErrorMessage(msg string) bool {
+	return strings.Contains(msg, "Response size too big") ||
+		strings.Contains(msg, "Too many links")
 }
 
 // loadCDAAssets loads all published assets via CDA and attaches them as cdaView on matching CMA assets.
@@ -95,4 +205,164 @@ func (mc *MigrationClient) loadCDAAssets(ctx context.Context, spaceModel *SpaceM
 	}
 	logger.Info("Loaded %d CDA assets (%d matched CMA assets)", len(assets.Items), matched)
 	return nil
+}
+
+// updateEntries incrementally loads entries ordered by -sys.updatedAt, stopping
+// when it reaches an entry older than the cutoff.
+func (mc *MigrationClient) updateEntries(ctx context.Context, cutoff time.Time, logger *Logger) (map[string]*EntryEntity, error) {
+	col := mc.cma.Entries.List(ctx, mc.spaceID)
+	col.Query.Locale("*").Include(0).Limit(100).Order("sys.updatedAt", true)
+
+	updated := make(map[string]*EntryEntity)
+	done := false
+	for !done {
+		page, err := col.Next()
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch entries: %w", err)
+		}
+		if len(page.Items) == 0 {
+			break
+		}
+
+		for _, entry := range page.Items {
+			updatedAt, parseErr := time.Parse(time.RFC3339, entry.Sys.UpdatedAt)
+			if parseErr != nil {
+				return nil, fmt.Errorf("failed to parse updatedAt for entry %s: %w", entry.Sys.ID, parseErr)
+			}
+			if updatedAt.Before(cutoff) {
+				done = true
+				break
+			}
+			updated[entry.Sys.ID] = &EntryEntity{Entry: &entry, Client: mc}
+		}
+
+		if done || len(page.Items) < 100 {
+			break
+		}
+
+		col = page
+	}
+
+	logger.Info("Updated %d entries incrementally", len(updated))
+	return updated, nil
+}
+
+// updateAssets incrementally loads assets ordered by -sys.updatedAt, stopping
+// when it reaches an asset older than the cutoff.
+func (mc *MigrationClient) updateAssets(ctx context.Context, cutoff time.Time, logger *Logger) (map[string]*AssetEntity, error) {
+	col := mc.cma.Assets.List(ctx, mc.spaceID)
+	col.Query.Locale("*").Limit(100).Order("sys.updatedAt", true)
+
+	updated := make(map[string]*AssetEntity)
+	done := false
+	for !done {
+		page, err := col.Next()
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch assets: %w", err)
+		}
+		if len(page.Items) == 0 {
+			break
+		}
+
+		for _, asset := range page.Items {
+			updatedAt, parseErr := time.Parse(time.RFC3339, asset.Sys.UpdatedAt)
+			if parseErr != nil {
+				return nil, fmt.Errorf("failed to parse updatedAt for asset %s: %w", asset.Sys.ID, parseErr)
+			}
+			if updatedAt.Before(cutoff) {
+				done = true
+				break
+			}
+			updated[asset.Sys.ID] = &AssetEntity{Asset: &asset, Client: mc}
+		}
+
+		if done || len(page.Items) < 100 {
+			break
+		}
+
+		col = page
+	}
+
+	logger.Info("Updated %d assets incrementally", len(updated))
+	return updated, nil
+}
+
+// updateCDAEntries incrementally loads published entries via CDA ordered by -sys.updatedAt
+// and returns them for attachment to matching CMA entities.
+func (mc *MigrationClient) updateCDAEntries(ctx context.Context, cutoff time.Time, logger *Logger) (map[string]Entity, error) {
+	col := mc.cda.Entries.List(ctx, mc.spaceID)
+	col.Query.Locale("*").Include(0).Limit(100).Order("sys.updatedAt", true)
+
+	updated := make(map[string]Entity)
+	done := false
+	for !done {
+		page, err := col.Next()
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch CDA entries: %w", err)
+		}
+		if len(page.Items) == 0 {
+			break
+		}
+
+		for _, entry := range page.Items {
+			updatedAt, parseErr := time.Parse(time.RFC3339, entry.Sys.UpdatedAt)
+			if parseErr != nil {
+				return nil, fmt.Errorf("failed to parse updatedAt for CDA entry %s: %w", entry.Sys.ID, parseErr)
+			}
+			if updatedAt.Before(cutoff) {
+				done = true
+				break
+			}
+			updated[entry.Sys.ID] = &EntryEntity{Entry: &entry, Client: mc}
+		}
+
+		if done || len(page.Items) < 100 {
+			break
+		}
+
+		col = page
+	}
+
+	logger.Info("Updated %d CDA entry views incrementally", len(updated))
+	return updated, nil
+}
+
+// updateCDAAssets incrementally loads published assets via CDA ordered by -sys.updatedAt
+// and returns them for attachment to matching CMA assets.
+func (mc *MigrationClient) updateCDAAssets(ctx context.Context, cutoff time.Time, logger *Logger) (map[string]Entity, error) {
+	col := mc.cda.Assets.List(ctx, mc.spaceID)
+	col.Query.Locale("*").Limit(100).Order("sys.updatedAt", true)
+
+	updated := make(map[string]Entity)
+	done := false
+	for !done {
+		page, err := col.Next()
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch CDA assets: %w", err)
+		}
+		if len(page.Items) == 0 {
+			break
+		}
+
+		for _, asset := range page.Items {
+			updatedAt, parseErr := time.Parse(time.RFC3339, asset.Sys.UpdatedAt)
+			if parseErr != nil {
+				return nil, fmt.Errorf("failed to parse updatedAt for CDA asset %s: %w", asset.Sys.ID, parseErr)
+			}
+			if updatedAt.Before(cutoff) {
+				done = true
+				break
+			}
+			updated[asset.Sys.ID] = &AssetEntity{Asset: &asset, Client: mc}
+		}
+
+		if done || len(page.Items) < 100 {
+			break
+		}
+
+		col = page
+	}
+
+	logger.Info("Updated %d CDA asset views incrementally", len(updated))
+	return updated, nil
 }


### PR DESCRIPTION
### Description

Adds incremental space-model updates and improves initial cache loading performance.

### Type of Change

<!-- Check the relevant option -->

- [ ] 🐛 Bug fix
- [X] ✨ New feature
- [ ] 💥 Breaking change
- [X] 📝 Documentation
- [ ] ♻️ Refactoring
- [X] ⚡ Performance
- [X] ✅ Tests
- [ ] 🔧 Build/CI

### Related Issue

<!-- Link related issues: Fixes #123, Closes #456 -->

## Changes

- Add UpdateSpaceModel to refresh only entities changed since the previous load/update.
- Serialize full reloads and incremental updates, and swap rebuilt cache/model state atomically.
- Make cache reads use RWMutex and avoid mutating live cache/model maps during incremental updates.
- Preserve existing CDA views where appropriate and replace entity wrappers instead of mutating returned entities.
- Include exact-cutoff timestamps during incremental updates to avoid missing rounded Contentful timestamps.
- Replace fixed 512 initial entry loading with adaptive per-content-type loading:
    - starts at page size 1000
    - uses 3 content-type workers
    - retries only failing content types with halved page sizes on Contentful response-size errors

- Apply the same adaptive strategy to initial CDA entry view loading.
- Document incremental updates and adaptive initial entry loading.
-

### Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have performed a self-review of my own code.
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.

#### Notes

<!-- Optional: Add additional context -->
