### PR TITLE
feat: content-model helpers, validation, save/publish, locale filters…

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A Go library for Contentful migrations that provides a high-level interface for 
 
 - **Unified Entity Interface**: Work with both Contentful entries and assets through a common interface
 - **Space Model Caching**: Load and cache entire space models for efficient operations
+- **Content Model Helpers**: Safe lookup helpers for content types, fields, and validation metadata
 - **Dual CMA/CDA Loading**: Load management (CMA) and delivery (CDA) views side-by-side for diff-style comparisons
 - **Locale-Aware Operations**: Native support for Contentful's localization system with locale-specific field access
 - **Type-Safe Field Access**: Specialized methods for different field types (string, float64, bool, references)
@@ -25,6 +26,7 @@ A Go library for Contentful migrations that provides a high-level interface for 
 - **Collection Operations**: Chain operations like filtering, mapping, grouping, and reducing
 - **Migration Execution**: Execute batch operations with dry-run support, concurrent execution, and comprehensive error handling
 - **DeepL Translation**: Built-in DeepL API integration for automated field translation with cost tracking
+- **Basic RichText Markdown Conversion**: Convert supported Contentful RichText documents to/from a safe Markdown subset
 - **Incremental Cache Updates**: Efficiently refresh only recently changed entities using `UpdateSpaceModel`, ordered by `-sys.updatedAt`
 - **Concurrent Loading**: Parallel loading of entries and assets for faster space initialization, with adaptive per-content-type entry page sizes
 - **Selective Loading**: Skip asset loading with `SkipAssets` to save time and bandwidth when only entries are needed
@@ -193,6 +195,26 @@ filtered := client.FilterEntities(
     commanderclient.FilterByUpdatedAfter(time.Now().AddDate(0, -1, 0)),
 )
 ```
+
+### Content Model Helpers
+
+After the space model is loaded, `MigrationClient` can safely look up content model metadata without reaching into `SpaceModel` directly:
+
+```go
+contentType, ok := client.GetContentType("article")
+if !ok {
+    log.Println("content type is missing or the space model is not loaded")
+} else {
+    log.Printf("Content type: %s", contentType.Name)
+}
+
+field, ok := client.GetContentTypeField("article", "title")
+if ok && commanderclient.FieldIsEditable(field) {
+    log.Printf("Field %s can be edited", field.ID)
+}
+```
+
+Both helpers return `false` when the space model is not loaded, when the content type or field is missing, or when the cached model contains nil entries.
 
 ### Incremental Cache Updates
 
@@ -390,11 +412,56 @@ if err := categoryEntity.GetFieldValueInto("catalogueQuery", commanderclient.Loc
 }
 ```
 
+### Field Validation Metadata
+
+Content model fields can expose validation metadata such as size limits, allowed values, and regular expressions. Because `contentful.Field` is defined in the Contentful SDK, these helpers are ordinary package functions:
+
+```go
+field, ok := client.GetContentTypeField("article", "slug")
+if !ok {
+    log.Fatal("missing field")
+}
+
+if commanderclient.FieldIsEditable(field) {
+    log.Println("field is editable")
+}
+if maxLength, ok := commanderclient.FieldMaxLength(field); ok {
+    log.Printf("max length: %d", maxLength)
+}
+if minLength, ok := commanderclient.FieldMinLength(field); ok {
+    log.Printf("min length: %d", minLength)
+}
+if allowedValues, ok := commanderclient.FieldAllowedValues(field); ok {
+    log.Printf("allowed values: %v", allowedValues)
+}
+if pattern, flags, ok := commanderclient.FieldRegex(field); ok {
+    log.Printf("regex: /%s/%s", pattern, flags)
+}
+
+summary := commanderclient.GetFieldValidationSummary(field)
+```
+
+`FieldMaxLength` returns the lowest non-zero max from `size` validations, and `FieldMinLength` returns the highest min. `FieldAllowedValues` returns the first predefined-values validation. `GetFieldValidationSummary` returns a serializable `FieldValidationSummary`:
+
+```go
+type FieldValidationSummary struct {
+    MinLength     *int  `json:"minLength,omitempty"`
+    MaxLength     *int  `json:"maxLength,omitempty"`
+    AllowedValues []any `json:"allowedValues,omitempty"`
+    RegexPattern  string `json:"regexPattern,omitempty"`
+    RegexFlags    string `json:"regexFlags,omitempty"`
+}
+```
+
 ### Entity-Specific Methods
 
 ```go
 // Get title (uses content type display field for entries, asset title for assets)
 title := entity.GetTitle(commanderclient.Locale("en"))
+
+// Get the raw locale value of the content type display field.
+// Unlike GetTitle, this does not apply locale fallback.
+displayName := client.GetEntryDisplayName(entity, commanderclient.Locale("en"))
 
 // Get description (assets only, returns empty string for entries)
 description := entity.GetDescription(commanderclient.Locale("en"))
@@ -406,6 +473,65 @@ if file != nil {
     fmt.Printf("URL: %s\n", file.URL)
 }
 ```
+
+## RichText Markdown Conversion
+
+For service integrations that need a simple editable text format, Contentful RichText can be converted to and from a supported Markdown subset:
+
+```go
+value := entity.GetFieldValue("body", commanderclient.Locale("en"))
+
+markdown, warnings, err := commanderclient.RichTextToMarkdown(value)
+if err != nil {
+    log.Fatal(err)
+}
+for _, warning := range warnings {
+    log.Printf("RichText warning: %s", warning)
+}
+
+if err := commanderclient.IsSupportedRichTextMarkdown(markdown); err != nil {
+    log.Fatal(err)
+}
+
+richText, err := commanderclient.MarkdownToRichText(markdown)
+if err != nil {
+    log.Fatal(err)
+}
+entity.SetFieldValue("body", commanderclient.Locale("de"), richText)
+```
+
+Supported Markdown/RichText constructs:
+
+- Document root
+- Paragraphs
+- Headings levels 1-3
+- Unordered and ordered lists
+- List items
+- Bold and italic text
+- Hyperlinks (see below)
+- Tables (see below)
+- Plain text line breaks where practical
+
+### Hyperlinks
+
+- External links round-trip as standard Markdown: `[text](https://example.com)`.
+- Entry and asset hyperlinks have no URL, so they use a custom scheme that round-trips losslessly: `[text](entry:<id>)` and `[text](asset:<id>)`.
+- Link text may itself contain bold/italic, e.g. `[**bold** label](https://example.com)`.
+- Images (`![alt](url)`) remain unsupported and are rejected on write.
+
+### Tables
+
+Tables convert to and from [GitHub-Flavored Markdown](https://github.github.com/gfm/#tables-extension-) pipe tables:
+
+```
+| Name | Price |
+| --- | --- |
+| Widget | 9.99 |
+```
+
+The first row is the header row, and cells hold inline content (text, bold/italic, links). Because GFM tables cannot represent everything Contentful tables can, content that does not fit is degraded with a `warnings` entry on read: block content inside a cell (lists, multiple paragraphs) is flattened to text, header cells outside the first row become regular cells, a table with no header row uses its first row as the header, and ragged rows are padded to the column count.
+
+Unsupported Markdown is rejected on write so callers do not accidentally persist lossy RichText. Unsupported RichText nodes encountered while reading are rendered as plain text where possible and reported in `warnings`. Unsupported constructs include embedded entries, embedded assets, images, arbitrary custom nodes, raw HTML, code spans, code blocks, blockquotes, and horizontal rules.
 
 ## Locale Support
 
@@ -441,6 +567,14 @@ englishEntries := client.FilterEntities(
 // Filter by field value with fallback to default locale
 entriesWithWelcome := client.FilterEntities(
     commanderclient.FilterByFieldValueWithFallback("title", commanderclient.Locale("fr"), defaultLocale, "Welcome"),
+)
+
+// Filter by empty/not-empty field values for a specific locale
+missingGermanDescriptions := client.FilterEntities(
+    commanderclient.FilterByFieldEmptyWithLocale("description", commanderclient.Locale("de")),
+)
+englishDescriptions := client.FilterEntities(
+    commanderclient.FilterByFieldNotEmptyWithLocale("description", commanderclient.Locale("en")),
 )
 
 // Filter by locale availability
@@ -650,6 +784,27 @@ title := asset.GetFieldValueAsString("title", commanderclient.Locale("en")) // R
 
 The library supports the following migration operations, each defined as a constant for type safety:
 
+### Direct Draft Save and Publish
+
+For service code that is not building a migration batch, use the explicit convenience methods on `MigrationClient`:
+
+```go
+entity.SetFieldValue("title", commanderclient.Locale("en"), "Updated title")
+
+// Persist the current in-memory fields without publishing.
+// This does not republish an entity that was previously published.
+if err := client.SaveDraft(ctx, entity); err != nil {
+    log.Fatal(err)
+}
+
+// Publish the entity when the caller explicitly wants to make it live.
+if err := client.Publish(ctx, entity); err != nil {
+    log.Fatal(err)
+}
+```
+
+`SaveDraft` uses the same persistence behavior as `OperationUpsert`, and `Publish` uses the same publish behavior as `OperationPublish`, without dry-run or interactive confirmation.
+
 ### Available Operations
 
 ```go
@@ -784,6 +939,9 @@ commanderclient.FilterByUpdatedAfter(time)
 commanderclient.FilterByFieldValue("status", "active")
 commanderclient.FilterByFieldExists("description")
 commanderclient.FilterByFieldContains("title", "important")
+commanderclient.FilterByFieldValueWithLocale("title", commanderclient.Locale("en"), "Welcome")
+commanderclient.FilterByFieldEmptyWithLocale("description", commanderclient.Locale("de"))
+commanderclient.FilterByFieldNotEmptyWithLocale("description", commanderclient.Locale("en"))
 
 // ID patterns
 commanderclient.FilterByIDPattern("prod-")

--- a/commanderclient/client.go
+++ b/commanderclient/client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"reflect"
 	"sync"
 	"time"
 
@@ -307,6 +308,68 @@ func (mc *MigrationClient) GetSpaceModel() *SpaceModel {
 	return mc.spaceModel
 }
 
+// GetContentType retrieves a content type by ID from the loaded space model.
+func (mc *MigrationClient) GetContentType(contentTypeID string) (*contentful.ContentType, bool) {
+	if mc == nil {
+		return nil, false
+	}
+
+	mc.cacheMu.RLock()
+	defer mc.cacheMu.RUnlock()
+
+	if mc.spaceModel == nil || mc.spaceModel.ContentTypes == nil {
+		return nil, false
+	}
+
+	contentType, exists := mc.spaceModel.ContentTypes[contentTypeID]
+	if !exists || contentType == nil {
+		return nil, false
+	}
+	return contentType, true
+}
+
+// GetContentTypeField retrieves a field from a content type in the loaded space model.
+func (mc *MigrationClient) GetContentTypeField(contentTypeID string, fieldID string) (*contentful.Field, bool) {
+	contentType, exists := mc.GetContentType(contentTypeID)
+	if !exists {
+		return nil, false
+	}
+
+	for _, field := range contentType.Fields {
+		if field != nil && field.ID == fieldID {
+			return field, true
+		}
+	}
+	return nil, false
+}
+
+// GetEntryDisplayName returns the raw locale value of the content type display field, or the entity ID.
+func (mc *MigrationClient) GetEntryDisplayName(entity Entity, locale Locale) string {
+	if isNilEntity(entity) {
+		return ""
+	}
+
+	entityID := entity.GetID()
+	contentTypeID := entity.GetContentType()
+	if contentTypeID == "" {
+		return entityID
+	}
+
+	contentType, exists := mc.GetContentType(contentTypeID)
+	if !exists || contentType.DisplayField == "" {
+		return entityID
+	}
+
+	value := entity.GetFieldValue(contentType.DisplayField, locale)
+	if isNullOrEmpty(value) {
+		return entityID
+	}
+	if stringValue, ok := value.(string); ok {
+		return stringValue
+	}
+	return fmt.Sprintf("%v", value)
+}
+
 // GetEntity retrieves an entity by ID from cache
 func (mc *MigrationClient) GetEntity(id string) (Entity, bool) {
 	mc.cacheMu.RLock()
@@ -438,6 +501,89 @@ func (mc *MigrationClient) RefreshEntity(ctx context.Context, id string) error {
 	}
 
 	return fmt.Errorf("entity %s not found", id)
+}
+
+// SaveDraft persists the current in-memory entity fields without publishing.
+func (mc *MigrationClient) SaveDraft(ctx context.Context, entity Entity) error {
+	if err := mc.validateEntityMutation(entity); err != nil {
+		return err
+	}
+
+	executor := NewMigrationExecutor(mc, &MigrationOptions{DryRun: false, Confirm: false})
+	_, err := executor.upsertEntity(ctx, &MigrationOperation{
+		EntityID:  entity.GetID(),
+		Operation: OperationUpsert,
+		Entity:    entity,
+	})
+	if err != nil {
+		return fmt.Errorf("save draft failed for %s %q: %w", entity.GetType(), entity.GetID(), err)
+	}
+	return nil
+}
+
+// Publish publishes the entity. It does not persist unsaved in-memory field
+// edits — call SaveDraft first if the entity has been modified.
+func (mc *MigrationClient) Publish(ctx context.Context, entity Entity) error {
+	if err := mc.validateEntityMutation(entity); err != nil {
+		return err
+	}
+
+	executor := NewMigrationExecutor(mc, &MigrationOptions{DryRun: false, Confirm: false})
+	_, err := executor.publishEntity(ctx, &MigrationOperation{
+		EntityID:  entity.GetID(),
+		Operation: OperationPublish,
+		Entity:    entity,
+	})
+	if err != nil {
+		return fmt.Errorf("publish failed for %s %q: %w", entity.GetType(), entity.GetID(), err)
+	}
+	return nil
+}
+
+func (mc *MigrationClient) validateEntityMutation(entity Entity) error {
+	if mc == nil {
+		return fmt.Errorf("migration client is nil")
+	}
+	if mc.cma == nil {
+		return fmt.Errorf("migration client has no CMA client")
+	}
+	if isNilEntity(entity) {
+		return fmt.Errorf("entity is nil")
+	}
+
+	switch typed := entity.(type) {
+	case *EntryEntity:
+		if typed.Entry == nil {
+			return fmt.Errorf("entry entity has nil entry")
+		}
+		if typed.Entry.Sys == nil {
+			return fmt.Errorf("entry entity has nil sys")
+		}
+	case *AssetEntity:
+		if typed.Asset == nil {
+			return fmt.Errorf("asset entity has nil asset")
+		}
+		if typed.Asset.Sys == nil {
+			return fmt.Errorf("asset entity has nil sys")
+		}
+	default:
+		return fmt.Errorf("unsupported entity type %T", entity)
+	}
+
+	return nil
+}
+
+func isNilEntity(entity Entity) bool {
+	if entity == nil {
+		return true
+	}
+	value := reflect.ValueOf(entity)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
 }
 
 // RemoveEntity removes an entity from the cache

--- a/commanderclient/collection.go
+++ b/commanderclient/collection.go
@@ -489,6 +489,20 @@ func FilterByFieldExistsWithLocale(fieldName string, locale Locale) EntityFilter
 	}
 }
 
+// FilterByFieldEmptyWithLocale returns a filter for entities where a field is empty for a locale.
+func FilterByFieldEmptyWithLocale(fieldName string, locale Locale) EntityFilter {
+	return func(entity Entity) bool {
+		return entity.IsFieldNullOrEmpty(fieldName, locale)
+	}
+}
+
+// FilterByFieldNotEmptyWithLocale returns a filter for entities where a field is not empty for a locale.
+func FilterByFieldNotEmptyWithLocale(fieldName string, locale Locale) EntityFilter {
+	return func(entity Entity) bool {
+		return !entity.IsFieldNullOrEmpty(fieldName, locale)
+	}
+}
+
 // FilterHasCDAView returns a filter for entities that have a CDA view attached
 func FilterHasCDAView() EntityFilter {
 	return func(entity Entity) bool {

--- a/commanderclient/content_model_helpers_test.go
+++ b/commanderclient/content_model_helpers_test.go
@@ -1,0 +1,177 @@
+package commanderclient
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/foomo/contentful"
+)
+
+func TestGetContentTypeAndFieldNilSafe(t *testing.T) {
+	var nilClient *MigrationClient
+	if contentType, ok := nilClient.GetContentType("article"); ok || contentType != nil {
+		t.Fatal("expected nil client content type lookup to fail")
+	}
+
+	client := &MigrationClient{}
+	if contentType, ok := client.GetContentType("article"); ok || contentType != nil {
+		t.Fatal("expected unloaded space model content type lookup to fail")
+	}
+
+	client.spaceModel = &SpaceModel{
+		ContentTypes: map[string]*contentful.ContentType{
+			"article": {
+				Fields: []*contentful.Field{
+					nil,
+					{ID: "title", Name: "Title"},
+				},
+			},
+			"nilType": nil,
+		},
+	}
+
+	if contentType, ok := client.GetContentType("article"); !ok || contentType == nil {
+		t.Fatal("expected content type lookup to succeed")
+	}
+	if contentType, ok := client.GetContentType("nilType"); ok || contentType != nil {
+		t.Fatal("expected nil content type lookup to fail")
+	}
+	if field, ok := client.GetContentTypeField("article", "title"); !ok || field == nil {
+		t.Fatal("expected field lookup to succeed")
+	}
+	if field, ok := client.GetContentTypeField("article", "missing"); ok || field != nil {
+		t.Fatal("expected missing field lookup to fail")
+	}
+}
+
+func TestFieldValidationHelpers(t *testing.T) {
+	field := &contentful.Field{
+		Validations: []contentful.FieldValidation{
+			&contentful.FieldValidationSize{Size: &contentful.MinMax{Min: 2, Max: 50}},
+			contentful.FieldValidationSize{Size: &contentful.MinMax{Min: 5, Max: 20}},
+			&contentful.FieldValidationPredefinedValues{In: []interface{}{"General", "iOS"}},
+			contentful.FieldValidationRegex{Regex: &contentful.Regex{Pattern: "^such", Flags: "im"}},
+		},
+	}
+
+	if !FieldIsEditable(field) {
+		t.Fatal("expected field to be editable")
+	}
+	if FieldIsEditable(&contentful.Field{Disabled: true}) {
+		t.Fatal("expected disabled field not to be editable")
+	}
+	if FieldIsEditable(&contentful.Field{Omitted: true}) {
+		t.Fatal("expected omitted field not to be editable")
+	}
+
+	if maxLength, ok := FieldMaxLength(field); !ok || maxLength != 20 {
+		t.Fatalf("expected strictest max length 20, got %d (%t)", maxLength, ok)
+	}
+	if minLength, ok := FieldMinLength(field); !ok || minLength != 5 {
+		t.Fatalf("expected strictest min length 5, got %d (%t)", minLength, ok)
+	}
+	if values, ok := FieldAllowedValues(field); !ok || len(values) != 2 || values[0] != "General" {
+		t.Fatalf("expected allowed values, got %#v (%t)", values, ok)
+	}
+	if pattern, flags, ok := FieldRegex(field); !ok || pattern != "^such" || flags != "im" {
+		t.Fatalf("expected regex ^such/im, got %q/%q (%t)", pattern, flags, ok)
+	}
+
+	summary := GetFieldValidationSummary(field)
+	if summary.MinLength == nil || *summary.MinLength != 5 {
+		t.Fatalf("expected summary min length 5, got %#v", summary.MinLength)
+	}
+	if summary.MaxLength == nil || *summary.MaxLength != 20 {
+		t.Fatalf("expected summary max length 20, got %#v", summary.MaxLength)
+	}
+	if len(summary.AllowedValues) != 2 {
+		t.Fatalf("expected summary allowed values, got %#v", summary.AllowedValues)
+	}
+	if summary.RegexPattern != "^such" || summary.RegexFlags != "im" {
+		t.Fatalf("expected summary regex ^such/im, got %q/%q", summary.RegexPattern, summary.RegexFlags)
+	}
+}
+
+func TestGetEntryDisplayNameUsesRawLocaleValue(t *testing.T) {
+	client := &MigrationClient{
+		spaceModel: &SpaceModel{
+			ContentTypes: map[string]*contentful.ContentType{
+				"article": {DisplayField: "title"},
+			},
+		},
+	}
+	entity := &EntryEntity{
+		Entry: &contentful.Entry{
+			Sys: &contentful.Sys{
+				ID: "entry-id",
+				ContentType: &contentful.ContentType{
+					Sys: &contentful.Sys{ID: "article"},
+				},
+			},
+			Fields: map[string]any{
+				"title": map[string]any{
+					"en-US": "English title",
+				},
+			},
+		},
+	}
+
+	if displayName := client.GetEntryDisplayName(entity, Locale("en-US")); displayName != "English title" {
+		t.Fatalf("expected locale display name, got %q", displayName)
+	}
+	if displayName := client.GetEntryDisplayName(entity, Locale("de-DE")); displayName != "entry-id" {
+		t.Fatalf("expected no fallback and entity ID, got %q", displayName)
+	}
+}
+
+func TestFilterByFieldEmptyWithLocale(t *testing.T) {
+	entity := &EntryEntity{
+		Entry: &contentful.Entry{
+			Sys: &contentful.Sys{ID: "entry-id", ContentType: &contentful.ContentType{Sys: &contentful.Sys{ID: "article"}}},
+			Fields: map[string]any{
+				"title": map[string]any{
+					"en-US": "Title",
+					"de-DE": "",
+				},
+			},
+		},
+	}
+
+	if !FilterByFieldEmptyWithLocale("title", Locale("de-DE"))(entity) {
+		t.Fatal("expected empty locale filter to match")
+	}
+	if FilterByFieldEmptyWithLocale("title", Locale("en-US"))(entity) {
+		t.Fatal("expected empty locale filter not to match")
+	}
+	if !FilterByFieldNotEmptyWithLocale("title", Locale("en-US"))(entity) {
+		t.Fatal("expected not-empty locale filter to match")
+	}
+}
+
+func TestSaveDraftPublishPreconditions(t *testing.T) {
+	ctx := context.Background()
+
+	var nilClient *MigrationClient
+	if err := nilClient.SaveDraft(ctx, nil); err == nil || !strings.Contains(err.Error(), "migration client is nil") {
+		t.Fatalf("expected nil client error, got %v", err)
+	}
+
+	clientWithoutCMA := &MigrationClient{}
+	if err := clientWithoutCMA.Publish(ctx, &EntryEntity{}); err == nil || !strings.Contains(err.Error(), "no CMA client") {
+		t.Fatalf("expected missing CMA error, got %v", err)
+	}
+
+	client := newMigrationClient("token", "", "space", "master")
+	var nilEntry *EntryEntity
+	if err := client.SaveDraft(ctx, nilEntry); err == nil || !strings.Contains(err.Error(), "entity is nil") {
+		t.Fatalf("expected nil entity error, got %v", err)
+	}
+	if err := client.Publish(ctx, unsupportedEntity{}); err == nil || !strings.Contains(err.Error(), "unsupported entity type") {
+		t.Fatalf("expected unsupported entity error, got %v", err)
+	}
+}
+
+type unsupportedEntity struct {
+	Entity
+}

--- a/commanderclient/field_validation.go
+++ b/commanderclient/field_validation.go
@@ -22,22 +22,22 @@ func FieldMaxLength(field *contentful.Field) (int, bool) {
 		return 0, false
 	}
 
-	var max int
+	var maxSize int
 	for _, validation := range field.Validations {
 		size := fieldValidationSize(validation)
 		if size == nil || size.Size == nil || size.Size.Max <= 0 {
 			continue
 		}
 		current := int(size.Size.Max)
-		if max == 0 || current < max {
-			max = current
+		if maxSize == 0 || current < maxSize {
+			maxSize = current
 		}
 	}
 
-	if max == 0 {
+	if maxSize == 0 {
 		return 0, false
 	}
-	return max, true
+	return maxSize, true
 }
 
 // FieldMinLength returns the strictest min size validation for the field.
@@ -46,22 +46,22 @@ func FieldMinLength(field *contentful.Field) (int, bool) {
 		return 0, false
 	}
 
-	var min int
+	var minSize int
 	for _, validation := range field.Validations {
 		size := fieldValidationSize(validation)
 		if size == nil || size.Size == nil || size.Size.Min <= 0 {
 			continue
 		}
 		current := int(size.Size.Min)
-		if current > min {
-			min = current
+		if current > minSize {
+			minSize = current
 		}
 	}
 
-	if min == 0 {
+	if minSize == 0 {
 		return 0, false
 	}
-	return min, true
+	return minSize, true
 }
 
 // FieldAllowedValues returns the first predefined-values validation for the field.

--- a/commanderclient/field_validation.go
+++ b/commanderclient/field_validation.go
@@ -1,0 +1,155 @@
+package commanderclient
+
+import "github.com/foomo/contentful"
+
+// FieldValidationSummary contains normalized field validation values for UI/API serialization.
+type FieldValidationSummary struct {
+	MinLength     *int   `json:"minLength,omitempty"`
+	MaxLength     *int   `json:"maxLength,omitempty"`
+	AllowedValues []any  `json:"allowedValues,omitempty"`
+	RegexPattern  string `json:"regexPattern,omitempty"`
+	RegexFlags    string `json:"regexFlags,omitempty"`
+}
+
+// FieldIsEditable returns true when the field exists and is neither disabled nor omitted.
+func FieldIsEditable(field *contentful.Field) bool {
+	return field != nil && !field.Disabled && !field.Omitted
+}
+
+// FieldMaxLength returns the strictest max size validation for the field.
+func FieldMaxLength(field *contentful.Field) (int, bool) {
+	if field == nil {
+		return 0, false
+	}
+
+	var max int
+	for _, validation := range field.Validations {
+		size := fieldValidationSize(validation)
+		if size == nil || size.Size == nil || size.Size.Max <= 0 {
+			continue
+		}
+		current := int(size.Size.Max)
+		if max == 0 || current < max {
+			max = current
+		}
+	}
+
+	if max == 0 {
+		return 0, false
+	}
+	return max, true
+}
+
+// FieldMinLength returns the strictest min size validation for the field.
+func FieldMinLength(field *contentful.Field) (int, bool) {
+	if field == nil {
+		return 0, false
+	}
+
+	var min int
+	for _, validation := range field.Validations {
+		size := fieldValidationSize(validation)
+		if size == nil || size.Size == nil || size.Size.Min <= 0 {
+			continue
+		}
+		current := int(size.Size.Min)
+		if current > min {
+			min = current
+		}
+	}
+
+	if min == 0 {
+		return 0, false
+	}
+	return min, true
+}
+
+// FieldAllowedValues returns the first predefined-values validation for the field.
+func FieldAllowedValues(field *contentful.Field) ([]any, bool) {
+	if field == nil {
+		return nil, false
+	}
+
+	for _, validation := range field.Validations {
+		predefined := fieldValidationPredefinedValues(validation)
+		if predefined == nil || len(predefined.In) == 0 {
+			continue
+		}
+		values := make([]any, len(predefined.In))
+		copy(values, predefined.In)
+		return values, true
+	}
+
+	return nil, false
+}
+
+// FieldRegex returns the first regular-expression validation for the field.
+func FieldRegex(field *contentful.Field) (pattern string, flags string, ok bool) {
+	if field == nil {
+		return "", "", false
+	}
+
+	for _, validation := range field.Validations {
+		regex := fieldValidationRegex(validation)
+		if regex == nil || regex.Regex == nil || regex.Regex.Pattern == "" {
+			continue
+		}
+		return regex.Regex.Pattern, regex.Regex.Flags, true
+	}
+
+	return "", "", false
+}
+
+// GetFieldValidationSummary returns a normalized summary of supported field validations.
+func GetFieldValidationSummary(field *contentful.Field) FieldValidationSummary {
+	summary := FieldValidationSummary{}
+
+	if minLength, ok := FieldMinLength(field); ok {
+		summary.MinLength = &minLength
+	}
+	if maxLength, ok := FieldMaxLength(field); ok {
+		summary.MaxLength = &maxLength
+	}
+	if allowedValues, ok := FieldAllowedValues(field); ok {
+		summary.AllowedValues = allowedValues
+	}
+	if pattern, flags, ok := FieldRegex(field); ok {
+		summary.RegexPattern = pattern
+		summary.RegexFlags = flags
+	}
+
+	return summary
+}
+
+func fieldValidationSize(validation contentful.FieldValidation) *contentful.FieldValidationSize {
+	switch typed := validation.(type) {
+	case contentful.FieldValidationSize:
+		return &typed
+	case *contentful.FieldValidationSize:
+		return typed
+	default:
+		return nil
+	}
+}
+
+func fieldValidationPredefinedValues(validation contentful.FieldValidation) *contentful.FieldValidationPredefinedValues {
+	switch typed := validation.(type) {
+	case contentful.FieldValidationPredefinedValues:
+		return &typed
+	case *contentful.FieldValidationPredefinedValues:
+		return typed
+	default:
+		return nil
+	}
+}
+
+func fieldValidationRegex(validation contentful.FieldValidation) *contentful.FieldValidationRegex {
+	switch typed := validation.(type) {
+	case contentful.FieldValidationRegex:
+		return &typed
+	case *contentful.FieldValidationRegex:
+		return typed
+	default:
+		return nil
+	}
+}

--- a/commanderclient/richtext_internal.go
+++ b/commanderclient/richtext_internal.go
@@ -186,3 +186,37 @@ func (n *RichTextNode) setHyperlinkURI(uri string) {
 	}
 	n.Data["uri"] = uri
 }
+
+// getHyperlinkTarget returns the linkType ("Entry"/"Asset") and id from an
+// entry-hyperlink or asset-hyperlink node's data.target.sys structure.
+func (n *RichTextNode) getHyperlinkTarget() (linkType string, id string, ok bool) {
+	target, ok := n.Data["target"].(map[string]any)
+	if !ok {
+		return "", "", false
+	}
+	sys, ok := target["sys"].(map[string]any)
+	if !ok {
+		return "", "", false
+	}
+	linkType, _ = sys["linkType"].(string)
+	id, _ = sys["id"].(string)
+	if id == "" {
+		return "", "", false
+	}
+	return linkType, id, true
+}
+
+// setHyperlinkTarget sets the data.target.sys link structure for an
+// entry-hyperlink or asset-hyperlink node.
+func (n *RichTextNode) setHyperlinkTarget(linkType string, id string) {
+	if n.Data == nil {
+		n.Data = make(map[string]any)
+	}
+	n.Data["target"] = map[string]any{
+		"sys": map[string]any{
+			"type":     "Link",
+			"linkType": linkType,
+			"id":       id,
+		},
+	}
+}

--- a/commanderclient/richtext_markdown.go
+++ b/commanderclient/richtext_markdown.go
@@ -1,0 +1,884 @@
+package commanderclient
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var (
+	markdownHeadingPattern       = regexp.MustCompile(`^(#{1,6})\s+(.+)$`)
+	markdownUnorderedListPattern = regexp.MustCompile(`^(\s*)[-+*]\s+(.+)$`)
+	markdownOrderedListPattern   = regexp.MustCompile(`^(\s*)\d+[.)]\s+(.+)$`)
+	markdownImagePattern         = regexp.MustCompile(`!\[[^\]]*\]\([^)]*\)`)
+	markdownHTMLPattern          = regexp.MustCompile(`<[A-Za-z][^>]*>`)
+	tableDividerCellPattern      = regexp.MustCompile(`^:?-+:?$`)
+)
+
+// RichTextToMarkdown converts a Contentful RichText document to basic Markdown.
+func RichTextToMarkdown(value any) (markdown string, warnings []string, err error) {
+	node, err := parseRichText(value)
+	if err != nil {
+		return "", nil, err
+	}
+	if !node.isDocument() {
+		return "", nil, fmt.Errorf("value is not a Contentful RichText document")
+	}
+
+	markdown, warnings = richTextDocumentToMarkdown(node)
+	return markdown, warnings, nil
+}
+
+// MarkdownToRichText converts supported basic Markdown to a Contentful RichText document.
+func MarkdownToRichText(markdown string) (any, error) {
+	if err := IsSupportedRichTextMarkdown(markdown); err != nil {
+		return nil, err
+	}
+
+	content, err := markdownToRichTextBlocks(markdown)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RichTextNode{
+		NodeType: nodeTypeDocument,
+		Data:     map[string]any{},
+		Content:  content,
+	}, nil
+}
+
+// IsSupportedRichTextMarkdown validates that Markdown uses the supported v1 subset.
+func IsSupportedRichTextMarkdown(markdown string) error {
+	_, err := markdownToRichTextBlocks(markdown)
+	return err
+}
+
+func markdownToRichTextBlocks(markdown string) ([]*RichTextNode, error) {
+	markdown = strings.ReplaceAll(markdown, "\r\n", "\n")
+	markdown = strings.ReplaceAll(markdown, "\r", "\n")
+
+	if strings.TrimSpace(markdown) == "" {
+		return []*RichTextNode{}, nil
+	}
+	if markdownHTMLPattern.MatchString(markdown) {
+		return nil, fmt.Errorf("raw HTML is not supported in RichText Markdown")
+	}
+	if markdownImagePattern.MatchString(markdown) {
+		return nil, fmt.Errorf("images are not supported in RichText Markdown")
+	}
+	if strings.Contains(markdown, "`") {
+		return nil, fmt.Errorf("code spans and code blocks are not supported in RichText Markdown")
+	}
+
+	lines := strings.Split(markdown, "\n")
+	var blocks []*RichTextNode
+
+	for i := 0; i < len(lines); i++ {
+		line := lines[i]
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		if err := validateMarkdownLine(line); err != nil {
+			return nil, err
+		}
+
+		if match := markdownHeadingPattern.FindStringSubmatch(line); match != nil {
+			level := len(match[1])
+			if level > 3 {
+				return nil, fmt.Errorf("heading level %d is not supported", level)
+			}
+			content, err := markdownInlineToRichText(match[2])
+			if err != nil {
+				return nil, err
+			}
+			blocks = append(blocks, &RichTextNode{
+				NodeType: fmt.Sprintf("heading-%d", level),
+				Data:     map[string]any{},
+				Content:  content,
+			})
+			continue
+		}
+
+		if listType, _, ok, err := parseMarkdownListLine(line); err != nil {
+			return nil, err
+		} else if ok {
+			listNode := &RichTextNode{
+				NodeType: listType,
+				Data:     map[string]any{},
+			}
+			for ; i < len(lines); i++ {
+				currentLine := lines[i]
+				if strings.TrimSpace(currentLine) == "" {
+					break
+				}
+				currentListType, currentItemText, currentOK, currentErr := parseMarkdownListLine(currentLine)
+				if currentErr != nil {
+					return nil, currentErr
+				}
+				if !currentOK || currentListType != listType {
+					i--
+					break
+				}
+				content, err := markdownInlineToRichText(currentItemText)
+				if err != nil {
+					return nil, err
+				}
+				listNode.Content = append(listNode.Content, &RichTextNode{
+					NodeType: nodeTypeListItem,
+					Data:     map[string]any{},
+					Content: []*RichTextNode{{
+						NodeType: nodeTypeParagraph,
+						Data:     map[string]any{},
+						Content:  content,
+					}},
+				})
+			}
+			blocks = append(blocks, listNode)
+			continue
+		}
+
+		if isTableStart(lines, i) {
+			tableNode, lastLine, err := parseMarkdownTable(lines, i)
+			if err != nil {
+				return nil, err
+			}
+			blocks = append(blocks, tableNode)
+			i = lastLine
+			continue
+		}
+
+		paragraphLines := []string{line}
+		for i+1 < len(lines) {
+			nextLine := lines[i+1]
+			if strings.TrimSpace(nextLine) == "" {
+				break
+			}
+			if markdownHeadingPattern.MatchString(nextLine) {
+				break
+			}
+			if _, _, ok, err := parseMarkdownListLine(nextLine); err != nil {
+				return nil, err
+			} else if ok {
+				break
+			}
+			if isTableStart(lines, i+1) {
+				break
+			}
+			if err := validateMarkdownLine(nextLine); err != nil {
+				return nil, err
+			}
+			paragraphLines = append(paragraphLines, nextLine)
+			i++
+		}
+
+		content, err := markdownInlineToRichText(strings.Join(paragraphLines, "\n"))
+		if err != nil {
+			return nil, err
+		}
+		blocks = append(blocks, &RichTextNode{
+			NodeType: nodeTypeParagraph,
+			Data:     map[string]any{},
+			Content:  content,
+		})
+	}
+
+	return blocks, nil
+}
+
+func validateMarkdownLine(line string) error {
+	trimmed := strings.TrimSpace(line)
+	switch {
+	case strings.HasPrefix(trimmed, "```"), strings.HasPrefix(trimmed, "~~~"):
+		return fmt.Errorf("code blocks are not supported in RichText Markdown")
+	case strings.HasPrefix(trimmed, ">"):
+		return fmt.Errorf("blockquotes are not supported in RichText Markdown")
+	case trimmed == "---" || trimmed == "***" || trimmed == "___":
+		return fmt.Errorf("horizontal rules are not supported in RichText Markdown")
+	}
+	return nil
+}
+
+func parseMarkdownListLine(line string) (string, string, bool, error) {
+	if match := markdownUnorderedListPattern.FindStringSubmatch(line); match != nil {
+		if match[1] != "" {
+			return "", "", false, fmt.Errorf("nested or indented lists are not supported")
+		}
+		return nodeTypeUnorderedList, match[2], true, nil
+	}
+	if match := markdownOrderedListPattern.FindStringSubmatch(line); match != nil {
+		if match[1] != "" {
+			return "", "", false, fmt.Errorf("nested or indented lists are not supported")
+		}
+		return nodeTypeOrderedList, match[2], true, nil
+	}
+	return "", "", false, nil
+}
+
+// isTableStart reports whether a GFM table begins at line i: a row containing a pipe
+// followed by a divider line (e.g. "| --- | --- |").
+func isTableStart(lines []string, i int) bool {
+	if i+1 >= len(lines) {
+		return false
+	}
+	if strings.TrimSpace(lines[i]) == "" || !strings.Contains(lines[i], "|") {
+		return false
+	}
+	return isTableDivider(lines[i+1])
+}
+
+// isTableDivider reports whether a line is a GFM table divider (each cell is dashes
+// with optional alignment colons).
+func isTableDivider(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	if !strings.Contains(trimmed, "-") {
+		return false
+	}
+	cells := splitTableRow(trimmed)
+	if len(cells) == 0 {
+		return false
+	}
+	for _, cell := range cells {
+		if !tableDividerCellPattern.MatchString(strings.TrimSpace(cell)) {
+			return false
+		}
+	}
+	return true
+}
+
+// parseMarkdownTable consumes a table starting at the header line and returns the
+// table node plus the index of the last consumed line. Body rows are padded/truncated
+// to the header's column count (GFM behavior).
+func parseMarkdownTable(lines []string, start int) (*RichTextNode, int, error) {
+	headerCells := splitTableRow(lines[start])
+	columnCount := len(headerCells)
+
+	tableNode := &RichTextNode{NodeType: nodeTypeTable, Data: map[string]any{}}
+
+	headerRow, err := buildTableRow(headerCells, columnCount, true)
+	if err != nil {
+		return nil, 0, err
+	}
+	tableNode.Content = append(tableNode.Content, headerRow)
+
+	last := start + 1 // the divider line
+	for r := start + 2; r < len(lines); r++ {
+		if strings.TrimSpace(lines[r]) == "" || !strings.Contains(lines[r], "|") {
+			break
+		}
+		bodyRow, err := buildTableRow(splitTableRow(lines[r]), columnCount, false)
+		if err != nil {
+			return nil, 0, err
+		}
+		tableNode.Content = append(tableNode.Content, bodyRow)
+		last = r
+	}
+
+	return tableNode, last, nil
+}
+
+// buildTableRow builds a table-row node with columnCount cells, parsing each cell's
+// inline content. Missing cells are padded empty; extra cells are dropped.
+func buildTableRow(cells []string, columnCount int, header bool) (*RichTextNode, error) {
+	cellType := nodeTypeTableCell
+	if header {
+		cellType = nodeTypeTableHeaderCell
+	}
+	row := &RichTextNode{NodeType: nodeTypeTableRow, Data: map[string]any{}}
+	for c := range columnCount {
+		raw := ""
+		if c < len(cells) {
+			raw = cells[c]
+		}
+		cellText := strings.ReplaceAll(strings.TrimSpace(raw), `\|`, "|")
+		content, err := markdownInlineToRichText(cellText)
+		if err != nil {
+			return nil, err
+		}
+		row.Content = append(row.Content, &RichTextNode{
+			NodeType: cellType,
+			Data:     map[string]any{},
+			Content: []*RichTextNode{{
+				NodeType: nodeTypeParagraph,
+				Data:     map[string]any{},
+				Content:  content,
+			}},
+		})
+	}
+	return row, nil
+}
+
+// splitTableRow splits a table row on unescaped pipes, dropping the empty leading and
+// trailing cells produced by optional outer pipes.
+func splitTableRow(line string) []string {
+	parts := splitUnescaped(strings.TrimSpace(line), '|')
+	if len(parts) > 0 && strings.TrimSpace(parts[0]) == "" {
+		parts = parts[1:]
+	}
+	if len(parts) > 0 && strings.TrimSpace(parts[len(parts)-1]) == "" {
+		parts = parts[:len(parts)-1]
+	}
+	return parts
+}
+
+// splitUnescaped splits s on every unescaped occurrence of sep.
+func splitUnescaped(s string, sep byte) []string {
+	var parts []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == sep && !isEscapedAt(s, i) {
+			parts = append(parts, s[start:i])
+			start = i + 1
+		}
+	}
+	return append(parts, s[start:])
+}
+
+func markdownInlineToRichText(text string) ([]*RichTextNode, error) {
+	return markdownInlineToRichTextWithMarks(text, nil)
+}
+
+func markdownInlineToRichTextWithMarks(text string, marks []RichTextMark) ([]*RichTextNode, error) {
+	var nodes []*RichTextNode
+	for len(text) > 0 {
+		marker, markTypes, markerIndex := nextMarkdownMark(text)
+		link, linkIndex := nextMarkdownLink(text)
+
+		// Process a link if it appears before the next mark (or there is no mark).
+		if linkIndex != -1 && (markerIndex == -1 || linkIndex < markerIndex) {
+			if linkIndex > 0 {
+				nodes = appendMarkdownTextNode(nodes, text[:linkIndex], marks)
+			}
+			linkContent, err := markdownInlineToRichTextWithMarks(link.label, marks)
+			if err != nil {
+				return nil, err
+			}
+			nodes = append(nodes, buildHyperlinkNode(link.target, linkContent))
+			text = text[link.end:]
+			continue
+		}
+
+		if markerIndex == -1 {
+			nodes = appendMarkdownTextNode(nodes, text, marks)
+			break
+		}
+
+		if markerIndex > 0 {
+			nodes = appendMarkdownTextNode(nodes, text[:markerIndex], marks)
+		}
+
+		start := markerIndex + len(marker)
+		endOffset := indexUnescaped(text[start:], marker)
+		if endOffset == -1 {
+			return nil, fmt.Errorf("unclosed Markdown mark %q", marker)
+		}
+		end := start + endOffset
+		if end == start {
+			return nil, fmt.Errorf("empty Markdown mark %q is not supported", marker)
+		}
+
+		childMarks := copyRichTextMarks(marks)
+		for _, markType := range markTypes {
+			childMarks = append(childMarks, RichTextMark{Type: markType})
+		}
+		childNodes, err := markdownInlineToRichTextWithMarks(text[start:end], childMarks)
+		if err != nil {
+			return nil, err
+		}
+		nodes = append(nodes, childNodes...)
+		text = text[end+len(marker):]
+	}
+
+	return nodes, nil
+}
+
+func nextMarkdownMark(text string) (marker string, markTypes []string, index int) {
+	candidates := []struct {
+		marker string
+		marks  []string
+	}{
+		{marker: "***", marks: []string{markTypeBold, markTypeItalic}},
+		{marker: "___", marks: []string{markTypeBold, markTypeItalic}},
+		{marker: "**", marks: []string{markTypeBold}},
+		{marker: "__", marks: []string{markTypeBold}},
+		{marker: "*", marks: []string{markTypeItalic}},
+		{marker: "_", marks: []string{markTypeItalic}},
+	}
+
+	index = -1
+	for _, candidate := range candidates {
+		candidateIndex := indexUnescaped(text, candidate.marker)
+		if candidateIndex == -1 {
+			continue
+		}
+		if index == -1 || candidateIndex < index || candidateIndex == index && len(candidate.marker) > len(marker) {
+			marker = candidate.marker
+			markTypes = candidate.marks
+			index = candidateIndex
+		}
+	}
+	return marker, markTypes, index
+}
+
+// indexUnescaped returns the index of the first occurrence of marker in s that
+// is not preceded by a Markdown backslash escape, or -1 if there is none.
+func indexUnescaped(s, marker string) int {
+	from := 0
+	for {
+		idx := strings.Index(s[from:], marker)
+		if idx == -1 {
+			return -1
+		}
+		abs := from + idx
+		if !isEscapedAt(s, abs) {
+			return abs
+		}
+		from = abs + 1
+	}
+}
+
+// isEscapedAt reports whether the byte at pos is preceded by an odd number of backslashes.
+func isEscapedAt(s string, pos int) bool {
+	backslashes := 0
+	for i := pos - 1; i >= 0 && s[i] == '\\'; i-- {
+		backslashes++
+	}
+	return backslashes%2 == 1
+}
+
+type markdownLink struct {
+	label  string
+	target string
+	end    int
+}
+
+// nextMarkdownLink finds the earliest unescaped [label](target) link in text that
+// is not an image. It returns the parsed link and the index of its opening '[',
+// or index -1 when there is none.
+func nextMarkdownLink(text string) (markdownLink, int) {
+	search := 0
+	for {
+		open := indexUnescaped(text[search:], "[")
+		if open == -1 {
+			return markdownLink{}, -1
+		}
+		open += search
+
+		// Skip image syntax: an unescaped '!' immediately before '['.
+		if open > 0 && text[open-1] == '!' && !isEscapedAt(text, open-1) {
+			search = open + 1
+			continue
+		}
+
+		closeLabel := indexUnescaped(text[open+1:], "]")
+		if closeLabel == -1 {
+			return markdownLink{}, -1
+		}
+		closeLabel += open + 1
+
+		if closeLabel+1 >= len(text) || text[closeLabel+1] != '(' {
+			search = open + 1
+			continue
+		}
+		openParen := closeLabel + 1
+
+		closeParen := indexUnescaped(text[openParen+1:], ")")
+		if closeParen == -1 {
+			search = open + 1
+			continue
+		}
+		closeParen += openParen + 1
+
+		label := text[open+1 : closeLabel]
+		target := text[openParen+1 : closeParen]
+		if label == "" || target == "" {
+			search = open + 1
+			continue
+		}
+		return markdownLink{label: label, target: target, end: closeParen + 1}, open
+	}
+}
+
+// buildHyperlinkNode constructs a hyperlink node from a link target. The entry:/asset:
+// schemes map to entry/asset hyperlinks; any other target is treated as an external uri.
+func buildHyperlinkNode(target string, content []*RichTextNode) *RichTextNode {
+	node := &RichTextNode{
+		Data:    map[string]any{},
+		Content: content,
+	}
+	switch {
+	case strings.HasPrefix(target, "entry:"):
+		node.NodeType = nodeTypeEntryHyperlink
+		node.setHyperlinkTarget("Entry", unescapeMarkdownText(strings.TrimPrefix(target, "entry:")))
+	case strings.HasPrefix(target, "asset:"):
+		node.NodeType = nodeTypeAssetHyperlink
+		node.setHyperlinkTarget("Asset", unescapeMarkdownText(strings.TrimPrefix(target, "asset:")))
+	default:
+		node.NodeType = nodeTypeHyperlink
+		node.setHyperlinkURI(unescapeMarkdownText(target))
+	}
+	return node
+}
+
+func appendMarkdownTextNode(nodes []*RichTextNode, value string, marks []RichTextMark) []*RichTextNode {
+	value = unescapeMarkdownText(value)
+	if value == "" {
+		return nodes
+	}
+	return append(nodes, &RichTextNode{
+		NodeType: nodeTypeText,
+		Value:    value,
+		Data:     map[string]any{},
+		Marks:    copyRichTextMarks(marks),
+	})
+}
+
+func copyRichTextMarks(marks []RichTextMark) []RichTextMark {
+	if len(marks) == 0 {
+		return []RichTextMark{}
+	}
+	out := make([]RichTextMark, len(marks))
+	copy(out, marks)
+	return out
+}
+
+func richTextDocumentToMarkdown(node *RichTextNode) (string, []string) {
+	var blocks []string
+	var warnings []string
+	for _, child := range node.Content {
+		block, childWarnings := richTextBlockToMarkdown(child)
+		warnings = append(warnings, childWarnings...)
+		if strings.TrimSpace(block) != "" {
+			blocks = append(blocks, block)
+		}
+	}
+	return strings.Join(blocks, "\n\n"), warnings
+}
+
+func richTextBlockToMarkdown(node *RichTextNode) (string, []string) {
+	if node == nil {
+		return "", nil
+	}
+
+	switch node.NodeType {
+	case nodeTypeParagraph:
+		return richTextInlineToMarkdown(node.Content)
+	case nodeTypeHeading1, nodeTypeHeading2, nodeTypeHeading3:
+		level := strings.TrimPrefix(node.NodeType, "heading-")
+		text, warnings := richTextInlineToMarkdown(node.Content)
+		return strings.Repeat("#", int(level[0]-'0')) + " " + text, warnings
+	case nodeTypeHeading4, nodeTypeHeading5, nodeTypeHeading6:
+		text, warnings := richTextInlineToMarkdown(node.Content)
+		warnings = append(warnings, fmt.Sprintf("unsupported RichText node %q rendered as plain text", node.NodeType))
+		return text, warnings
+	case nodeTypeUnorderedList:
+		return richTextListToMarkdown(node, false)
+	case nodeTypeOrderedList:
+		return richTextListToMarkdown(node, true)
+	case nodeTypeTable:
+		return richTextTableToMarkdown(node)
+	case nodeTypeText, nodeTypeHyperlink, nodeTypeEntryHyperlink, nodeTypeAssetHyperlink:
+		return richTextInlineNodeToMarkdown(node)
+	default:
+		text, warnings := richTextInlineToMarkdown(node.Content)
+		warnings = append(warnings, fmt.Sprintf("unsupported RichText node %q rendered as plain text where possible", node.NodeType))
+		return text, warnings
+	}
+}
+
+func richTextListToMarkdown(node *RichTextNode, ordered bool) (string, []string) {
+	var lines []string
+	var warnings []string
+	itemNumber := 0
+	for _, child := range node.Content {
+		if child == nil {
+			continue
+		}
+		if child.NodeType != nodeTypeListItem {
+			childMarkdown, childWarnings := richTextBlockToMarkdown(child)
+			warnings = append(warnings, childWarnings...)
+			warnings = append(warnings, fmt.Sprintf("unsupported child node %q in list rendered as plain text", child.NodeType))
+			if childMarkdown != "" {
+				lines = append(lines, childMarkdown)
+			}
+			continue
+		}
+
+		itemNumber++
+		itemText, childWarnings := richTextListItemToMarkdown(child)
+		warnings = append(warnings, childWarnings...)
+		prefix := "- "
+		if ordered {
+			prefix = fmt.Sprintf("%d. ", itemNumber)
+		}
+		lines = append(lines, prefix+itemText)
+	}
+	return strings.Join(lines, "\n"), warnings
+}
+
+func richTextListItemToMarkdown(node *RichTextNode) (string, []string) {
+	var parts []string
+	var warnings []string
+	for _, child := range node.Content {
+		if child == nil {
+			continue
+		}
+		if child.NodeType == nodeTypeParagraph {
+			text, childWarnings := richTextInlineToMarkdown(child.Content)
+			warnings = append(warnings, childWarnings...)
+			parts = append(parts, text)
+			continue
+		}
+		text, childWarnings := richTextBlockToMarkdown(child)
+		warnings = append(warnings, childWarnings...)
+		warnings = append(warnings, fmt.Sprintf("unsupported RichText list item child %q rendered as plain text", child.NodeType))
+		parts = append(parts, text)
+	}
+	return strings.Join(parts, " "), warnings
+}
+
+// richTextTableToMarkdown renders a table node as a GitHub-flavored Markdown table.
+// Row 0 becomes the header row (GFM requires one). Content GFM cannot represent —
+// block content in cells, header cells outside row 0, ragged rows — degrades with warnings.
+func richTextTableToMarkdown(node *RichTextNode) (string, []string) {
+	var warnings []string
+
+	var rowNodes []*RichTextNode
+	for _, child := range node.Content {
+		if child == nil {
+			continue
+		}
+		if child.NodeType != nodeTypeTableRow {
+			warnings = append(warnings, fmt.Sprintf("unsupported table child node %q ignored", child.NodeType))
+			continue
+		}
+		rowNodes = append(rowNodes, child)
+	}
+	if len(rowNodes) == 0 {
+		return "", warnings
+	}
+
+	rows := make([][]string, len(rowNodes))
+	columnCount := 0
+	for r, rowNode := range rowNodes {
+		var cells []string
+		for _, cellNode := range rowNode.Content {
+			if cellNode == nil {
+				continue
+			}
+			if cellNode.NodeType == nodeTypeTableHeaderCell && r != 0 {
+				warnings = append(warnings, "table header cell outside the first row rendered as a regular cell")
+			}
+			cellText, cellWarnings := richTextTableCellToMarkdown(cellNode)
+			warnings = append(warnings, cellWarnings...)
+			cells = append(cells, cellText)
+		}
+		rows[r] = cells
+		if len(cells) > columnCount {
+			columnCount = len(cells)
+		}
+	}
+	if columnCount == 0 {
+		return "", warnings
+	}
+
+	if !rowIsAllHeaderCells(rowNodes[0]) {
+		warnings = append(warnings, "table first row used as the Markdown header row")
+	}
+
+	var lines []string
+	for r, cells := range rows {
+		if len(cells) != columnCount {
+			warnings = append(warnings, "ragged table row padded to match column count")
+			for len(cells) < columnCount {
+				cells = append(cells, "")
+			}
+		}
+		lines = append(lines, "| "+strings.Join(cells, " | ")+" |")
+		if r == 0 {
+			divider := make([]string, columnCount)
+			for i := range divider {
+				divider[i] = "---"
+			}
+			lines = append(lines, "| "+strings.Join(divider, " | ")+" |")
+		}
+	}
+	return strings.Join(lines, "\n"), warnings
+}
+
+func rowIsAllHeaderCells(rowNode *RichTextNode) bool {
+	hasCell := false
+	for _, cell := range rowNode.Content {
+		if cell == nil {
+			continue
+		}
+		hasCell = true
+		if cell.NodeType != nodeTypeTableHeaderCell {
+			return false
+		}
+	}
+	return hasCell
+}
+
+// richTextTableCellToMarkdown flattens a cell's content to single-line inline text,
+// escaping pipes and collapsing newlines. Block content is flattened with a warning.
+func richTextTableCellToMarkdown(node *RichTextNode) (string, []string) {
+	var parts []string
+	var warnings []string
+	for _, child := range node.Content {
+		if child == nil {
+			continue
+		}
+		if child.NodeType == nodeTypeParagraph {
+			text, childWarnings := richTextInlineToMarkdown(child.Content)
+			warnings = append(warnings, childWarnings...)
+			parts = append(parts, text)
+			continue
+		}
+		text, childWarnings := richTextBlockToMarkdown(child)
+		warnings = append(warnings, childWarnings...)
+		warnings = append(warnings, fmt.Sprintf("table cell child %q flattened to text", child.NodeType))
+		parts = append(parts, text)
+	}
+	return escapeTableCell(strings.Join(parts, " ")), warnings
+}
+
+// escapeTableCell makes inline text safe for a single GFM table cell.
+func escapeTableCell(text string) string {
+	text = strings.ReplaceAll(text, "\n", " ")
+	text = strings.ReplaceAll(text, "|", `\|`)
+	return strings.TrimSpace(text)
+}
+
+func richTextInlineToMarkdown(nodes []*RichTextNode) (string, []string) {
+	var builder strings.Builder
+	var warnings []string
+	for _, child := range nodes {
+		text, childWarnings := richTextInlineNodeToMarkdown(child)
+		warnings = append(warnings, childWarnings...)
+		builder.WriteString(text)
+	}
+	return builder.String(), warnings
+}
+
+func richTextInlineNodeToMarkdown(node *RichTextNode) (string, []string) {
+	if node == nil {
+		return "", nil
+	}
+
+	switch node.NodeType {
+	case nodeTypeText:
+		text := escapeMarkdownText(node.Value)
+		var warnings []string
+		hasBold := false
+		hasItalic := false
+		for _, mark := range node.Marks {
+			switch mark.Type {
+			case markTypeBold:
+				hasBold = true
+			case markTypeItalic:
+				hasItalic = true
+			default:
+				warnings = append(warnings, fmt.Sprintf("unsupported RichText mark %q ignored", mark.Type))
+			}
+		}
+		switch {
+		case hasBold && hasItalic:
+			text = "***" + text + "***"
+		case hasBold:
+			text = "**" + text + "**"
+		case hasItalic:
+			text = "*" + text + "*"
+		}
+		return text, warnings
+	case nodeTypeHyperlink, nodeTypeEntryHyperlink, nodeTypeAssetHyperlink:
+		return richTextHyperlinkToMarkdown(node)
+	default:
+		text, warnings := richTextInlineToMarkdown(node.Content)
+		if node.NodeType != "" {
+			warnings = append(warnings, fmt.Sprintf("unsupported RichText inline node %q rendered as plain text where possible", node.NodeType))
+		}
+		return text, warnings
+	}
+}
+
+// richTextHyperlinkToMarkdown renders a hyperlink node as [label](target). External
+// hyperlinks use their uri; entry/asset hyperlinks use the entry:/asset: id scheme.
+func richTextHyperlinkToMarkdown(node *RichTextNode) (string, []string) {
+	label, warnings := richTextInlineToMarkdown(node.Content)
+
+	switch node.NodeType {
+	case nodeTypeHyperlink:
+		uri := node.getHyperlinkURI()
+		if uri == "" {
+			warnings = append(warnings, "hyperlink node missing uri rendered as plain text")
+			return label, warnings
+		}
+		return "[" + label + "](" + escapeMarkdownURL(uri) + ")", warnings
+	case nodeTypeEntryHyperlink, nodeTypeAssetHyperlink:
+		_, id, ok := node.getHyperlinkTarget()
+		if !ok {
+			warnings = append(warnings, fmt.Sprintf("%s node missing target rendered as plain text", node.NodeType))
+			return label, warnings
+		}
+		scheme := "entry"
+		if node.NodeType == nodeTypeAssetHyperlink {
+			scheme = "asset"
+		}
+		return "[" + label + "](" + scheme + ":" + escapeMarkdownURL(id) + ")", warnings
+	default:
+		return label, warnings
+	}
+}
+
+func escapeMarkdownText(text string) string {
+	replacer := strings.NewReplacer(
+		`\`, `\\`,
+		`*`, `\*`,
+		`_`, `\_`,
+		`[`, `\[`,
+		`]`, `\]`,
+		`(`, `\(`,
+		`)`, `\)`,
+		`#`, `\#`,
+	)
+	return replacer.Replace(text)
+}
+
+// escapeMarkdownURL escapes only the characters that would break the (...) of a
+// Markdown link target; reversed by unescapeMarkdownText.
+func escapeMarkdownURL(url string) string {
+	replacer := strings.NewReplacer(
+		`\`, `\\`,
+		`(`, `\(`,
+		`)`, `\)`,
+	)
+	return replacer.Replace(url)
+}
+
+// unescapeMarkdownText reverses escapeMarkdownText, stripping the backslash from
+// escaped Markdown metacharacters so text nodes round-trip to their original value.
+func unescapeMarkdownText(text string) string {
+	if !strings.Contains(text, `\`) {
+		return text
+	}
+	var builder strings.Builder
+	builder.Grow(len(text))
+	for i := 0; i < len(text); i++ {
+		if text[i] == '\\' && i+1 < len(text) && isMarkdownEscapable(text[i+1]) {
+			builder.WriteByte(text[i+1])
+			i++
+			continue
+		}
+		builder.WriteByte(text[i])
+	}
+	return builder.String()
+}
+
+func isMarkdownEscapable(c byte) bool {
+	switch c {
+	case '\\', '*', '_', '[', ']', '(', ')', '#':
+		return true
+	default:
+		return false
+	}
+}

--- a/commanderclient/richtext_markdown_test.go
+++ b/commanderclient/richtext_markdown_test.go
@@ -1,0 +1,404 @@
+package commanderclient
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMarkdownToRichTextAndBackBasicSubset(t *testing.T) {
+	input := "# Title\n\nParagraph with **bold** and *italic*\nline two\n\n- One\n- Two\n\n1. First\n2. Second"
+
+	value, err := MarkdownToRichText(input)
+	if err != nil {
+		t.Fatalf("MarkdownToRichText returned error: %v", err)
+	}
+
+	node, err := parseRichText(value)
+	if err != nil {
+		t.Fatalf("parseRichText returned error: %v", err)
+	}
+	if !node.isDocument() {
+		t.Fatal("expected document node")
+	}
+	if len(node.Content) != 4 {
+		t.Fatalf("expected 4 top-level blocks, got %d", len(node.Content))
+	}
+
+	output, warnings, err := RichTextToMarkdown(value)
+	if err != nil {
+		t.Fatalf("RichTextToMarkdown returned error: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings, got %#v", warnings)
+	}
+	if output != input {
+		t.Fatalf("expected round trip markdown:\n%s\n\ngot:\n%s", input, output)
+	}
+}
+
+func TestIsSupportedRichTextMarkdownRejectsUnsupportedConstructs(t *testing.T) {
+	tests := []struct {
+		name     string
+		markdown string
+	}{
+		{name: "raw HTML", markdown: "<p>Hello</p>"},
+		{name: "image", markdown: "![Alt](image.jpg)"},
+		{name: "code", markdown: "`code`"},
+		{name: "heading 4", markdown: "#### Heading"},
+		{name: "blockquote", markdown: "> Quote"},
+		{name: "nested list", markdown: "- One\n  - Two"},
+		{name: "horizontal rule", markdown: "---"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := IsSupportedRichTextMarkdown(tt.markdown); err == nil {
+				t.Fatal("expected unsupported Markdown error")
+			}
+		})
+	}
+}
+
+func TestRichTextToMarkdownWarnsAndPreservesSupportedText(t *testing.T) {
+	value := &RichTextNode{
+		NodeType: nodeTypeDocument,
+		Data:     map[string]any{},
+		Content: []*RichTextNode{
+			{
+				NodeType: nodeTypeParagraph,
+				Data:     map[string]any{},
+				Content: []*RichTextNode{
+					{
+						NodeType: nodeTypeText,
+						Value:    "Plain ",
+						Data:     map[string]any{},
+						Marks:    []RichTextMark{},
+					},
+					{
+						NodeType: nodeTypeHyperlink,
+						Data:     map[string]any{"uri": "https://example.com"},
+						Content: []*RichTextNode{{
+							NodeType: nodeTypeText,
+							Value:    "link",
+							Data:     map[string]any{},
+							Marks:    []RichTextMark{},
+						}},
+					},
+				},
+			},
+			{
+				NodeType: nodeTypeEmbeddedEntry,
+				Data:     map[string]any{},
+			},
+		},
+	}
+
+	markdown, warnings, err := RichTextToMarkdown(value)
+	if err != nil {
+		t.Fatalf("RichTextToMarkdown returned error: %v", err)
+	}
+	if markdown != "Plain [link](https://example.com)" {
+		t.Fatalf("expected hyperlink to be preserved, got %q", markdown)
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("expected one warning (embedded entry), got %#v", warnings)
+	}
+}
+
+func TestRichTextToMarkdownRejectsNonDocument(t *testing.T) {
+	if _, _, err := RichTextToMarkdown("not rich text"); err == nil {
+		t.Fatal("expected non-document RichText error")
+	}
+}
+
+func TestRichTextMarkdownBoldItalicRoundTrip(t *testing.T) {
+	doc := &RichTextNode{
+		NodeType: nodeTypeDocument,
+		Data:     map[string]any{},
+		Content: []*RichTextNode{{
+			NodeType: nodeTypeParagraph,
+			Data:     map[string]any{},
+			Content: []*RichTextNode{{
+				NodeType: nodeTypeText,
+				Value:    "bold italic",
+				Data:     map[string]any{},
+				Marks:    []RichTextMark{{Type: markTypeBold}, {Type: markTypeItalic}},
+			}},
+		}},
+	}
+
+	markdown, warnings, err := RichTextToMarkdown(doc)
+	if err != nil {
+		t.Fatalf("RichTextToMarkdown returned error: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings, got %#v", warnings)
+	}
+	if markdown != "***bold italic***" {
+		t.Fatalf("expected ***bold italic***, got %q", markdown)
+	}
+
+	value, err := MarkdownToRichText(markdown)
+	if err != nil {
+		t.Fatalf("MarkdownToRichText returned error: %v", err)
+	}
+	node := value.(*RichTextNode)
+	text := node.Content[0].Content[0]
+	if text.Value != "bold italic" {
+		t.Fatalf("expected round-tripped value, got %q", text.Value)
+	}
+	if len(text.Marks) != 2 {
+		t.Fatalf("expected bold and italic marks, got %#v", text.Marks)
+	}
+}
+
+func TestRichTextOrderedListNumberingSkipsNonItems(t *testing.T) {
+	listItem := func(text string) *RichTextNode {
+		return &RichTextNode{
+			NodeType: nodeTypeListItem,
+			Data:     map[string]any{},
+			Content: []*RichTextNode{{
+				NodeType: nodeTypeParagraph,
+				Data:     map[string]any{},
+				Content:  []*RichTextNode{{NodeType: nodeTypeText, Value: text, Data: map[string]any{}}},
+			}},
+		}
+	}
+
+	doc := &RichTextNode{
+		NodeType: nodeTypeDocument,
+		Data:     map[string]any{},
+		Content: []*RichTextNode{{
+			NodeType: nodeTypeOrderedList,
+			Data:     map[string]any{},
+			Content: []*RichTextNode{
+				nil,
+				{NodeType: nodeTypeEmbeddedEntry, Data: map[string]any{}},
+				listItem("first"),
+				listItem("second"),
+			},
+		}},
+	}
+
+	markdown, _, err := RichTextToMarkdown(doc)
+	if err != nil {
+		t.Fatalf("RichTextToMarkdown returned error: %v", err)
+	}
+	if markdown != "1. first\n2. second" {
+		t.Fatalf("expected sequential numbering, got %q", markdown)
+	}
+}
+
+func TestRichTextMarkdownEscapedTextRoundTrip(t *testing.T) {
+	values := []string{
+		"snake_case_var",
+		"C# is great (really)",
+		"a_b",
+		`back\slash`,
+		"asterisk * and brackets [x]",
+	}
+
+	for _, original := range values {
+		doc := &RichTextNode{
+			NodeType: nodeTypeDocument,
+			Data:     map[string]any{},
+			Content: []*RichTextNode{{
+				NodeType: nodeTypeParagraph,
+				Data:     map[string]any{},
+				Content:  []*RichTextNode{{NodeType: nodeTypeText, Value: original, Data: map[string]any{}}},
+			}},
+		}
+
+		markdown, _, err := RichTextToMarkdown(doc)
+		if err != nil {
+			t.Fatalf("RichTextToMarkdown(%q) returned error: %v", original, err)
+		}
+		value, err := MarkdownToRichText(markdown)
+		if err != nil {
+			t.Fatalf("MarkdownToRichText(%q) returned error: %v", markdown, err)
+		}
+		node := value.(*RichTextNode)
+		got := node.Content[0].Content[0].Value
+		if got != original {
+			t.Fatalf("round trip mismatch: original %q -> markdown %q -> %q", original, markdown, got)
+		}
+	}
+}
+
+func TestRichTextMarkdownHyperlinkRoundTrip(t *testing.T) {
+	inputs := []string{
+		"Visit [the site](https://example.com) now",
+		"A [**bold** link](https://example.com/path)",
+		"See [the product](entry:abc123) details",
+		"Download [the file](asset:xyz789)",
+		`Link with [parens](https://example.com/foo\(bar\)) here`,
+	}
+
+	for _, input := range inputs {
+		value, err := MarkdownToRichText(input)
+		if err != nil {
+			t.Fatalf("MarkdownToRichText(%q) error: %v", input, err)
+		}
+		output, warnings, err := RichTextToMarkdown(value)
+		if err != nil {
+			t.Fatalf("RichTextToMarkdown error: %v", err)
+		}
+		if len(warnings) != 0 {
+			t.Fatalf("unexpected warnings for %q: %#v", input, warnings)
+		}
+		if output != input {
+			t.Fatalf("round trip mismatch:\n in: %q\nout: %q", input, output)
+		}
+	}
+}
+
+func TestMarkdownToRichTextHyperlinkNodeTypes(t *testing.T) {
+	value, err := MarkdownToRichText("[ext](https://x.com) [e](entry:E1) [a](asset:A1)")
+	if err != nil {
+		t.Fatalf("MarkdownToRichText error: %v", err)
+	}
+	paragraph := value.(*RichTextNode).Content[0]
+
+	var links []*RichTextNode
+	for _, n := range paragraph.Content {
+		switch n.NodeType {
+		case nodeTypeHyperlink, nodeTypeEntryHyperlink, nodeTypeAssetHyperlink:
+			links = append(links, n)
+		}
+	}
+	if len(links) != 3 {
+		t.Fatalf("expected 3 hyperlink nodes, got %d", len(links))
+	}
+	if links[0].NodeType != nodeTypeHyperlink || links[0].getHyperlinkURI() != "https://x.com" {
+		t.Fatalf("external link wrong: %#v", links[0])
+	}
+	if lt, id, ok := links[1].getHyperlinkTarget(); !ok || lt != "Entry" || id != "E1" {
+		t.Fatalf("entry link wrong: %q %q %t", lt, id, ok)
+	}
+	if lt, id, ok := links[2].getHyperlinkTarget(); !ok || lt != "Asset" || id != "A1" {
+		t.Fatalf("asset link wrong: %q %q %t", lt, id, ok)
+	}
+}
+
+func TestRichTextMarkdownTableRoundTrip(t *testing.T) {
+	inputs := []string{
+		"| Name | Price |\n| --- | --- |\n| Widget | 9.99 |\n| Gadget | 19.99 |",
+		"| Name | Note |\n| --- | --- |\n| Widget | **new** |",
+		"| Link |\n| --- |\n| [site](https://example.com) |",
+	}
+
+	for _, input := range inputs {
+		value, err := MarkdownToRichText(input)
+		if err != nil {
+			t.Fatalf("MarkdownToRichText(%q) error: %v", input, err)
+		}
+		output, warnings, err := RichTextToMarkdown(value)
+		if err != nil {
+			t.Fatalf("RichTextToMarkdown error: %v", err)
+		}
+		if len(warnings) != 0 {
+			t.Fatalf("unexpected warnings for %q: %#v", input, warnings)
+		}
+		if output != input {
+			t.Fatalf("table round trip mismatch:\n in: %q\nout: %q", input, output)
+		}
+	}
+}
+
+func tableTextCell(cellType, text string) *RichTextNode {
+	return &RichTextNode{
+		NodeType: cellType,
+		Data:     map[string]any{},
+		Content: []*RichTextNode{{
+			NodeType: nodeTypeParagraph,
+			Data:     map[string]any{},
+			Content:  []*RichTextNode{{NodeType: nodeTypeText, Value: text, Data: map[string]any{}}},
+		}},
+	}
+}
+
+func tableRow(cells ...*RichTextNode) *RichTextNode {
+	return &RichTextNode{NodeType: nodeTypeTableRow, Data: map[string]any{}, Content: cells}
+}
+
+func tableDoc(rows ...*RichTextNode) *RichTextNode {
+	return &RichTextNode{
+		NodeType: nodeTypeDocument,
+		Data:     map[string]any{},
+		Content:  []*RichTextNode{{NodeType: nodeTypeTable, Data: map[string]any{}, Content: rows}},
+	}
+}
+
+func warningsContain(warnings []string, substr string) bool {
+	for _, w := range warnings {
+		if strings.Contains(w, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestRichTextTableReadRaggedRowWarns(t *testing.T) {
+	doc := tableDoc(
+		tableRow(tableTextCell(nodeTypeTableHeaderCell, "A"), tableTextCell(nodeTypeTableHeaderCell, "B")),
+		tableRow(tableTextCell(nodeTypeTableCell, "x")),
+	)
+
+	markdown, warnings, err := RichTextToMarkdown(doc)
+	if err != nil {
+		t.Fatalf("RichTextToMarkdown error: %v", err)
+	}
+	if !strings.Contains(markdown, "| x |  |") {
+		t.Fatalf("expected padded ragged row, got %q", markdown)
+	}
+	if !warningsContain(warnings, "ragged") {
+		t.Fatalf("expected ragged-row warning, got %#v", warnings)
+	}
+}
+
+func TestRichTextTableReadFlattensBlockCellWithWarning(t *testing.T) {
+	listCell := &RichTextNode{
+		NodeType: nodeTypeTableCell,
+		Data:     map[string]any{},
+		Content: []*RichTextNode{{
+			NodeType: nodeTypeUnorderedList,
+			Data:     map[string]any{},
+			Content: []*RichTextNode{{
+				NodeType: nodeTypeListItem,
+				Data:     map[string]any{},
+				Content: []*RichTextNode{{
+					NodeType: nodeTypeParagraph,
+					Data:     map[string]any{},
+					Content:  []*RichTextNode{{NodeType: nodeTypeText, Value: "one", Data: map[string]any{}}},
+				}},
+			}},
+		}},
+	}
+	doc := tableDoc(
+		tableRow(tableTextCell(nodeTypeTableHeaderCell, "A")),
+		tableRow(listCell),
+	)
+
+	_, warnings, err := RichTextToMarkdown(doc)
+	if err != nil {
+		t.Fatalf("RichTextToMarkdown error: %v", err)
+	}
+	if !warningsContain(warnings, "flattened") {
+		t.Fatalf("expected flatten warning, got %#v", warnings)
+	}
+}
+
+func TestRichTextTableReadNoHeaderRowWarns(t *testing.T) {
+	doc := tableDoc(
+		tableRow(tableTextCell(nodeTypeTableCell, "a"), tableTextCell(nodeTypeTableCell, "b")),
+		tableRow(tableTextCell(nodeTypeTableCell, "c"), tableTextCell(nodeTypeTableCell, "d")),
+	)
+
+	_, warnings, err := RichTextToMarkdown(doc)
+	if err != nil {
+		t.Fatalf("RichTextToMarkdown error: %v", err)
+	}
+	if !warningsContain(warnings, "first row used as the Markdown header") {
+		t.Fatalf("expected no-header warning, got %#v", warnings)
+	}
+}

--- a/commanderclient/update_debug_test.go
+++ b/commanderclient/update_debug_test.go
@@ -1,0 +1,105 @@
+package commanderclient
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestUpdateSpaceModelDebug is an interactive test for debugging UpdateSpaceModel.
+// It loads the space model, then loops waiting for you to edit entities in Contentful.
+// After each Enter keypress it calls UpdateSpaceModel and prints what changed.
+//
+// Run with:
+//
+//	go test ./commanderclient -run TestUpdateSpaceModelDebug -v -count=1
+//
+// Requires CONTENTFUL_CMAKEY, CONTENTFUL_SPACE_ID (and optionally CONTENTFUL_CDAKEY).
+func TestUpdateSpaceModelDebug(t *testing.T) {
+	if os.Getenv("CONTENTFUL_CMAKEY") == "" || os.Getenv("CONTENTFUL_SPACE_ID") == "" {
+		t.Skip("skipping: CONTENTFUL_CMAKEY and CONTENTFUL_SPACE_ID must be set")
+	}
+
+	config := LoadConfigFromEnv()
+	client, logger, err := Init(config)
+	if err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+
+	t.Logf("Loaded %d entities (last updated: %s)", len(client.cache), client.spaceModel.LastUpdated.Format("15:04:05.000"))
+
+	// Take a snapshot of current state
+	type snapshot struct {
+		version   int
+		updatedAt string
+	}
+	snap := make(map[string]snapshot, len(client.cache))
+	for id, entity := range client.cache {
+		snap[id] = snapshot{
+			version:   entity.GetVersion(),
+			updatedAt: entity.GetSys().UpdatedAt,
+		}
+	}
+
+	reader := bufio.NewReader(os.Stdin)
+	for i := 1; ; i++ {
+		fmt.Printf("\n--- Iteration %d ---\n", i)
+		fmt.Print("Edit entries in Contentful, then press Enter to update (or type 'q' + Enter to quit)... ")
+
+		input, readErr := reader.ReadString('\n')
+		if strings.TrimSpace(input) == "q" {
+			break
+		}
+		if readErr != nil {
+			// EOF (e.g. non-interactive run) — stop instead of looping forever.
+			break
+		}
+
+		if err := client.UpdateSpaceModel(context.Background(), logger); err != nil {
+			t.Fatalf("UpdateSpaceModel failed: %v", err)
+		}
+
+		// Diff against snapshot
+		changed := 0
+		added := 0
+		for id, entity := range client.cache {
+			prev, existed := snap[id]
+			if !existed {
+				added++
+				t.Logf("  + NEW  %-8s %-20s %s (v%d)",
+					entity.GetType(), entity.GetContentType(), id, entity.GetVersion())
+				continue
+			}
+			if entity.GetVersion() != prev.version || entity.GetSys().UpdatedAt != prev.updatedAt {
+				changed++
+				label := entity.GetTitle(client.GetDefaultLocale())
+				if label == "" {
+					label = id
+				}
+				t.Logf("  ~ CHG  %-8s %-20s %s  v%d→v%d  %s→%s",
+					entity.GetType(), entity.GetContentType(), label,
+					prev.version, entity.GetVersion(),
+					prev.updatedAt, entity.GetSys().UpdatedAt)
+			}
+		}
+
+		if changed == 0 && added == 0 {
+			t.Log("  (no changes detected)")
+		} else {
+			t.Logf("  Total: %d changed, %d new", changed, added)
+		}
+		t.Logf("  Cache size: %d entities (last updated: %s)", len(client.cache), client.spaceModel.LastUpdated.Format("15:04:05.000"))
+
+		// Refresh snapshot
+		snap = make(map[string]snapshot, len(client.cache))
+		for id, entity := range client.cache {
+			snap[id] = snapshot{
+				version:   entity.GetVersion(),
+				updatedAt: entity.GetSys().UpdatedAt,
+			}
+		}
+	}
+}


### PR DESCRIPTION
…, and RichText-Markdown conversion

### Description

Adds a set of independent capabilities to the `commanderclient` library:
  content-model and field-validation helpers, direct draft save/publish
  convenience methods, locale-aware empty/not-empty filters, and a new
  RichText ↔ Markdown converter (including hyperlinks and tables).

### Type of Change

<!-- Check the relevant option -->

- [ ] 🐛 Bug fix
- [X] ✨ New feature
- [ ] 💥 Breaking change
- [X] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance
- [X] ✅ Tests
- [ ] 🔧 Build/CI

### Related Issue

<!-- Link related issues: Fixes #123, Closes #456 -->

## Changes

- Content-model helpers: GetContentType, GetContentTypeField, and
    GetEntryDisplayName on MigrationClient (nil-safe cache lookups).
- Field validation metadata: FieldIsEditable, FieldMaxLength,
    FieldMinLength, FieldAllowedValues, FieldRegex, and
    GetFieldValidationSummary over contentful.Field.
- Direct draft save/publish: MigrationClient.SaveDraft and Publish
    convenience methods (mirroring OperationUpsert/OperationPublish),
    with nil/precondition validation.
- Locale filters: FilterByFieldEmptyWithLocale and
    FilterByFieldNotEmptyWithLocale.
- RichText <-> Markdown conversion: RichTextToMarkdown,
    MarkdownToRichText, and IsSupportedRichTextMarkdown over a safe
    subset: paragraphs, headings 1-3, ordered/unordered lists,
    bold/italic, hyperlinks (external plus entry:/asset: scheme), and
    GFM tables. Markdown metacharacters round-trip losslessly via
    backslash escaping; unsupported RichText degrades to plain text
    with warnings; unsupported Markdown (images, raw HTML, code,
    blockquotes, HRs) is rejected on write.

### Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.

#### Notes

<!-- Optional: Add additional context -->
