### PR TITLE
Version-safe write ops

### DIFF
--- a/commanderclient/client.go
+++ b/commanderclient/client.go
@@ -503,6 +503,32 @@ func (mc *MigrationClient) RefreshEntity(ctx context.Context, id string) error {
 	return fmt.Errorf("entity %s not found", id)
 }
 
+// syncEntityVersion fetches the current sys version for the entity from the CMA
+// and writes it back into the in-memory entity, leaving field edits intact. Used
+// to recover from a version conflict before retrying a write.
+func (mc *MigrationClient) syncEntityVersion(ctx context.Context, entity Entity) error {
+	switch e := entity.(type) {
+	case *EntryEntity:
+		latest, err := mc.cma.Entries.Get(ctx, mc.spaceID, e.Entry.Sys.ID)
+		if err != nil {
+			return err
+		}
+		e.Entry.Sys.Version = latest.Sys.Version
+		e.Entry.Sys.PublishedVersion = latest.Sys.PublishedVersion
+		return nil
+	case *AssetEntity:
+		latest, err := mc.cma.Assets.Get(ctx, mc.spaceID, e.Asset.Sys.ID)
+		if err != nil {
+			return err
+		}
+		e.Asset.Sys.Version = latest.Sys.Version
+		e.Asset.Sys.PublishedVersion = latest.Sys.PublishedVersion
+		return nil
+	default:
+		return fmt.Errorf("unsupported entity type %T", entity)
+	}
+}
+
 // SaveDraft persists the current in-memory entity fields without publishing.
 func (mc *MigrationClient) SaveDraft(ctx context.Context, entity Entity) error {
 	if err := mc.validateEntityMutation(entity); err != nil {

--- a/commanderclient/executor.go
+++ b/commanderclient/executor.go
@@ -3,6 +3,7 @@ package commanderclient
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -10,6 +11,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/foomo/contentful"
 )
 
 // MigrationOperation represents a migration operation to be performed
@@ -245,6 +248,22 @@ func (me *MigrationExecutor) GetErrorCount() int {
 	return count
 }
 
+// writeWithVersionRetry runs a CMA write and, on a Contentful version conflict
+// (HTTP 409), re-fetches the entity's current version from the server and retries
+// the write exactly once. Only Sys.Version/PublishedVersion are refreshed, so
+// locally-edited fields are preserved across the retry.
+func (me *MigrationExecutor) writeWithVersionRetry(ctx context.Context, entity Entity, write func() error) error {
+	err := write()
+	var mismatch contentful.VersionMismatchError
+	if err == nil || !errors.As(err, &mismatch) {
+		return err
+	}
+	if syncErr := me.client.syncEntityVersion(ctx, entity); syncErr != nil {
+		return fmt.Errorf("version conflict and version refresh failed: %w (original conflict: %w)", syncErr, err)
+	}
+	return write()
+}
+
 // upsertEntity updates an entity with new fields.
 // The SDK's Upsert decodes the API response into the entry/asset struct in-place,
 // so there is no need to re-fetch — the entity already carries the updated version.
@@ -260,7 +279,9 @@ func (me *MigrationExecutor) upsertEntity(ctx context.Context, op *MigrationOper
 		}
 
 		// Update the entry (SDK updates entry.Sys.Version in-place from the response)
-		err := me.client.cma.Entries.Upsert(ctx, me.client.spaceID, entry)
+		err := me.writeWithVersionRetry(ctx, op.Entity, func() error {
+			return me.client.cma.Entries.Upsert(ctx, me.client.spaceID, entry)
+		})
 		if err != nil {
 			return false, err
 		}
@@ -288,7 +309,9 @@ func (me *MigrationExecutor) upsertEntity(ctx context.Context, op *MigrationOper
 		}
 
 		// Update the asset (SDK updates asset.Sys.Version in-place from the response)
-		err := me.client.cma.Assets.Upsert(ctx, me.client.spaceID, asset)
+		err := me.writeWithVersionRetry(ctx, op.Entity, func() error {
+			return me.client.cma.Assets.Upsert(ctx, me.client.spaceID, asset)
+		})
 		if err != nil {
 			return false, err
 		}
@@ -333,7 +356,9 @@ func (me *MigrationExecutor) publishEntity(ctx context.Context, op *MigrationOpe
 		entryEntity := op.Entity.(*EntryEntity)
 		entry := entryEntity.Entry
 
-		err := me.client.cma.Entries.Publish(ctx, me.client.spaceID, entry)
+		err := me.writeWithVersionRetry(ctx, op.Entity, func() error {
+			return me.client.cma.Entries.Publish(ctx, me.client.spaceID, entry)
+		})
 		if err != nil {
 			return false, err
 		}
@@ -352,7 +377,9 @@ func (me *MigrationExecutor) publishEntity(ctx context.Context, op *MigrationOpe
 
 		// Assets.Publish updates the struct in-place, so no refresh is strictly needed,
 		// but we refresh to keep the cache consistent.
-		err := me.client.cma.Assets.Publish(ctx, me.client.spaceID, asset)
+		err := me.writeWithVersionRetry(ctx, op.Entity, func() error {
+			return me.client.cma.Assets.Publish(ctx, me.client.spaceID, asset)
+		})
 		if err != nil {
 			return false, err
 		}
@@ -369,7 +396,9 @@ func (me *MigrationExecutor) unpublishEntity(ctx context.Context, op *MigrationO
 		entryEntity := op.Entity.(*EntryEntity)
 		entry := entryEntity.Entry
 
-		err := me.client.cma.Entries.Unpublish(ctx, me.client.spaceID, entry)
+		err := me.writeWithVersionRetry(ctx, op.Entity, func() error {
+			return me.client.cma.Entries.Unpublish(ctx, me.client.spaceID, entry)
+		})
 		if err != nil {
 			return false, err
 		}
@@ -385,7 +414,9 @@ func (me *MigrationExecutor) unpublishEntity(ctx context.Context, op *MigrationO
 		asset := assetEntity.Asset
 
 		// Assets.Unpublish updates the struct in-place.
-		err := me.client.cma.Assets.Unpublish(ctx, me.client.spaceID, asset)
+		err := me.writeWithVersionRetry(ctx, op.Entity, func() error {
+			return me.client.cma.Assets.Unpublish(ctx, me.client.spaceID, asset)
+		})
 		if err != nil {
 			return false, err
 		}

--- a/commanderclient/version_conflict_test.go
+++ b/commanderclient/version_conflict_test.go
@@ -1,0 +1,165 @@
+package commanderclient
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/foomo/contentful"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const versionMismatchBody = `{"sys":{"type":"Error","id":"VersionMismatch"}}`
+
+func entryJSON(id string, version int) string {
+	return `{"sys":{"id":"` + id + `","type":"Entry","version":` +
+		strconv.Itoa(version) + `,"publishedVersion":1,"contentType":{"sys":{"id":"ct"}}},` +
+		`"fields":{"title":{"en-US":"server-side"}}}`
+}
+
+func newConflictTestEntry(id string) *EntryEntity {
+	return &EntryEntity{
+		Entry: &contentful.Entry{
+			Sys: &contentful.Sys{
+				ID:               id,
+				Version:          2,
+				PublishedVersion: 1,
+				ContentType:      &contentful.ContentType{Sys: &contentful.Sys{ID: "ct"}},
+			},
+			Fields: map[string]any{"title": map[string]any{"en-US": "edited"}},
+		},
+	}
+}
+
+// isPublish reports whether the request targets the .../published endpoint.
+func isPublish(r *http.Request) bool { return strings.HasSuffix(r.URL.Path, "/published") }
+
+func TestPublishRetriesOnVersionConflict(t *testing.T) {
+	var publishPUTs, gets int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet:
+			gets++
+			_, _ = io.WriteString(w, entryJSON("e1", 5))
+		case r.Method == http.MethodPut && isPublish(r):
+			publishPUTs++
+			if publishPUTs == 1 {
+				w.WriteHeader(http.StatusConflict)
+				_, _ = io.WriteString(w, versionMismatchBody)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := newMigrationClient("test-key", "", "test-space", "master")
+	client.cma.SetBaseURL(server.URL)
+
+	entity := newConflictTestEntry("e1")
+	err := client.Publish(context.Background(), entity)
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, publishPUTs, "should publish once, then retry once after refreshing version")
+	assert.GreaterOrEqual(t, gets, 1, "should re-fetch the entity to refresh its version")
+	assert.Equal(t, 5, entity.Entry.Sys.Version, "in-memory version should be refreshed from the server")
+}
+
+func TestSaveDraftRetriesOnVersionConflictPreservingFields(t *testing.T) {
+	var upsertPUTs int
+	var retryBody, retryVersionHeader string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet:
+			// Server reports a newer version with different field content; only the
+			// version should be adopted, never the server-side fields.
+			_, _ = io.WriteString(w, entryJSON("e2", 9))
+		case r.Method == http.MethodPut && !isPublish(r):
+			upsertPUTs++
+			if upsertPUTs == 1 {
+				w.WriteHeader(http.StatusConflict)
+				_, _ = io.WriteString(w, versionMismatchBody)
+				return
+			}
+			body, _ := io.ReadAll(r.Body)
+			retryBody = string(body)
+			retryVersionHeader = r.Header.Get("X-Contentful-Version")
+			_, _ = io.WriteString(w, entryJSON("e2", 10))
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := newMigrationClient("test-key", "", "test-space", "master")
+	client.cma.SetBaseURL(server.URL)
+
+	entity := newConflictTestEntry("e2")
+	err := client.SaveDraft(context.Background(), entity)
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, upsertPUTs, "should upsert once, then retry once")
+	assert.Equal(t, "9", retryVersionHeader, "retry must use the refreshed version")
+	assert.Contains(t, retryBody, "edited", "retry must preserve the locally-edited field")
+}
+
+func TestPublishSurfacesPersistentVersionConflict(t *testing.T) {
+	var publishPUTs int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet:
+			_, _ = io.WriteString(w, entryJSON("e3", 5))
+		case r.Method == http.MethodPut && isPublish(r):
+			publishPUTs++
+			w.WriteHeader(http.StatusConflict)
+			_, _ = io.WriteString(w, versionMismatchBody)
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := newMigrationClient("test-key", "", "test-space", "master")
+	client.cma.SetBaseURL(server.URL)
+
+	err := client.Publish(context.Background(), newConflictTestEntry("e3"))
+
+	require.Error(t, err)
+	assert.Equal(t, 2, publishPUTs, "must retry exactly once, not loop")
+	var mismatch contentful.VersionMismatchError
+	assert.ErrorAs(t, err, &mismatch, "the surfaced error should be a version mismatch")
+}
+
+func TestPublishDoesNotRetryNonConflictError(t *testing.T) {
+	var publishPUTs, gets int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet:
+			gets++
+			_, _ = io.WriteString(w, entryJSON("e4", 5))
+		case r.Method == http.MethodPut && isPublish(r):
+			publishPUTs++
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_, _ = io.WriteString(w, `{"sys":{"type":"Error","id":"InvalidEntry"},"message":"nope"}`)
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := newMigrationClient("test-key", "", "test-space", "master")
+	client.cma.SetBaseURL(server.URL)
+
+	err := client.Publish(context.Background(), newConflictTestEntry("e4"))
+
+	require.Error(t, err)
+	assert.Equal(t, 1, publishPUTs, "non-conflict errors must not be retried")
+	assert.Equal(t, 0, gets, "non-conflict errors must not trigger a version refresh")
+}


### PR DESCRIPTION
### Description

Version-safe write ops for entries that changed since the last sync

### Type of Change

<!-- Check the relevant option -->

- [ ] 🐛 Bug fix
- [X] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance
- [ ] ✅ Tests
- [ ] 🔧 Build/CI

### Related Issue

<!-- Link related issues: Fixes #123, Closes #456 -->

### Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have performed a self-review of my own code.
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.

#### Notes

<!-- Optional: Add additional context -->
